### PR TITLE
[Feat] 라우터 생성, 각 페이지와 네비게이션을 라우터에 연결 (#6, #7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@emotion/react": "^11.13.3",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.26.1"
       },
       "devDependencies": {
         "@emotion/babel-plugin": "^11.12.0",
@@ -28,7 +29,7 @@
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
         "eslint-plugin-react-refresh": "^0.4.9",
         "globals": "^15.9.0",
-        "husky": "^9.1.5",
+        "husky": "^8.0.0",
         "lint-staged": "^15.2.9",
         "prettier": "^3.3.3",
         "typescript": "^5.5.3",
@@ -1088,6 +1089,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.19.1.tgz",
+      "integrity": "sha512-S45oynt/WH19bHbIXjtli6QmwNYvaz+vtnubvNpNDvUOoA/OWh6j1OikIP3G+v5GHdxyC6EXoChG3HgYGEUfcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3669,16 +3679,16 @@
       }
     },
     "node_modules/husky": {
-      "version": "9.1.5",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.5.tgz",
-      "integrity": "sha512-rowAVRUBfI0b4+niA4SJMhfQwc107VLkBUgEYYAOQAbqDCnra1nYh83hF/MDmhYs9t9n1E3DuKOrs2LYNC+0Ag==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "husky": "bin.js"
+        "husky": "lib/bin.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
@@ -5154,6 +5164,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.26.1.tgz",
+      "integrity": "sha512-kIwJveZNwp7teQRI5QmwWo39A5bXRyqpH0COKKmPnyD2vBvDwgFXSqDUYtt1h+FEyfnE8eXr7oe0MxRzVwCcvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.19.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.26.1.tgz",
+      "integrity": "sha512-veut7m41S1fLql4pLhxeSW3jlqs+4MtjRLj0xvuCEXsxusJCbs6I8yn9BxzzDX2XDgafrccY6hwjmd/bL54tFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.19.1",
+        "react-router": "6.26.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "@emotion/react": "^11.13.3",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.1"
   },
   "devDependencies": {
     "@emotion/babel-plugin": "^11.12.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,10 @@ import {
 } from 'react-router-dom';
 
 import { PATH } from '@/constants/path';
+import RootLayout from '@/layouts/RootLayout';
+import Home from '@/pages/Home';
+import Search from '@/pages/Search';
+import Subscriptions from '@/pages/Subscriptions';
 
 const AuthProtectedRoute = () => {
   // 현재 경로와 URL쿼리 문자열 가져옴
@@ -28,14 +32,16 @@ const router = createBrowserRouter([
     children: [
       { path: PATH.SIGNIN, element: <div>SignIn</div> },
       {
+        //  <RootLayout /> : 네비게이션(탭바)+콘텐츠
+        element: <RootLayout />,
         children: [
           // 해당라우트가 부모라우트의 자식이야(true)-> Home으로 가
           // 부모라우트와 정확히 일치할 때 사용
-          { index: true, element: <div>Home</div> },
-          { path: PATH.SEARCH, children: [{ index: true, element: <div>Search</div> }] },
+          { index: true, element: <Home /> },
+          { path: PATH.SEARCH, children: [{ index: true, element: <Search /> }] },
           {
             path: PATH.SUBSCRIPTIONS,
-            children: [{ index: true, element: <div>Subscriptions</div> }],
+            children: [{ index: true, element: <Subscriptions /> }],
           },
           { path: PATH.MYPAGE, children: [{ index: true, element: <div>MyPage</div> }] },
           { path: PATH.SIGNIN, children: [{ index: true, element: <div>SignIn</div> }] },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,50 @@
-const App = () => <></>;
+import {
+  createBrowserRouter,
+  Navigate,
+  Outlet,
+  RouterProvider,
+  useLocation,
+} from 'react-router-dom';
+
+import { PATH } from '@/constants/path';
+
+const AuthProtectedRoute = () => {
+  // 현재 경로와 URL쿼리 문자열 가져옴
+  const { pathname, search } = useLocation();
+
+  const authOK = true; // 로그인 여부 확인(임시)
+
+  // 로그인 통과? 그럼 Outlet을 렌더링
+  // 로그인 실패? 로그인 페이지로 Redirect
+  // <Outlet/>: 자식 라우트를 렌더링
+  // replace: 현재 페이지를 브라우저 히스토리에서 교체
+  // state={..} :현재 URL 정보를 로그인 페이지로 전달
+  return authOK ? <Outlet /> : <Navigate to={`${PATH.SIGNIN}`} replace state={pathname + search} />;
+};
+const router = createBrowserRouter([
+  {
+    path: PATH.HOME,
+    element: <AuthProtectedRoute />,
+    children: [
+      { path: PATH.SIGNIN, element: <div>SignIn</div> },
+      {
+        children: [
+          // 해당라우트가 부모라우트의 자식이야(true)-> Home으로 가
+          // 부모라우트와 정확히 일치할 때 사용
+          { index: true, element: <div>Home</div> },
+          { path: PATH.SEARCH, children: [{ index: true, element: <div>Search</div> }] },
+          {
+            path: PATH.SUBSCRIPTIONS,
+            children: [{ index: true, element: <div>Subscriptions</div> }],
+          },
+          { path: PATH.MYPAGE, children: [{ index: true, element: <div>MyPage</div> }] },
+          { path: PATH.SIGNIN, children: [{ index: true, element: <div>SignIn</div> }] },
+        ],
+      },
+    ],
+  },
+]);
+
+const App = () => <RouterProvider router={router} />;
 
 export default App;

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -1,0 +1,13 @@
+export const PATH = {
+  HOME: '/',
+  SEARCH: '/search',
+  SUBSCRIPTIONS: '/subscriptions',
+  MYPAGE: '/mypage',
+  SIGNIN: '/signin',
+};
+export const PATH_TITLE = {
+  HOME: '홈',
+  SEARCH: '검색',
+  SUBSCRIPTIONS: '구독',
+  MYPAGE: '마이페이지',
+};

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,0 +1,14 @@
+import { Outlet } from 'react-router-dom';
+
+import Navbar from '@/layouts/layout/Navbar';
+
+const RootLayout = () => (
+  <div>
+    <Navbar />
+    <main>
+      <Outlet />
+    </main>
+  </div>
+);
+
+export default RootLayout;

--- a/src/layouts/layout/Navbar.tsx
+++ b/src/layouts/layout/Navbar.tsx
@@ -1,0 +1,27 @@
+import { NavLink } from 'react-router-dom';
+
+import { PATH, PATH_TITLE } from '@/constants/path';
+
+const Navbar = () => {
+  const menus = [
+    { path: PATH.HOME, title: PATH_TITLE.HOME },
+    { path: PATH.SEARCH, title: PATH_TITLE.SEARCH },
+    { path: PATH.SUBSCRIPTIONS, title: PATH_TITLE.SUBSCRIPTIONS },
+    { path: PATH.MYPAGE, title: PATH_TITLE.MYPAGE },
+  ];
+  return (
+    <nav>
+      <ul>
+        {menus.map(({ path, title }) => (
+          <li key={path}>
+            <NavLink to={path}>
+              <span>{title}</span>
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+};
+
+export default Navbar;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,8 @@
+const Home = () => (
+  <div>
+    <h1>Logo</h1>
+    <p>Home</p>
+  </div>
+);
+
+export default Home;

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -1,0 +1,3 @@
+const MyPage = () => <div>MyPage</div>;
+
+export default MyPage;

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,0 +1,3 @@
+const Search = () => <div>Search</div>;
+
+export default Search;

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -1,0 +1,3 @@
+const SignIn = () => <div>SignIn</div>;
+
+export default SignIn;

--- a/src/pages/Subscriptions.tsx
+++ b/src/pages/Subscriptions.tsx
@@ -1,0 +1,3 @@
+const Subscriptions = () => <div>Subscriptions</div>;
+
+export default Subscriptions;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
closes #6 , closes #7 
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

연결된 기능이라고 생각해서 이슈 2개가 묶여있는 점 참고바랍니다.

1. 라우터 초기생성(version 6)

- [x] App.tsx에 라우터 정의
- [x] path는 상수값으로 분리

2. 생성된 라우터를 기반으로 화면 하단에 보여질 네비게이션 메뉴 바 생성

- [x] 네비게이션 페이지 생성
- [x] 네비게이션 페이지 라우터에 연결

3. 각 페이지 연결 및 라우터에 연결

- [x] 각 메뉴의 페이지 생성 및 연결

## 🔧 변경 사항

- [ ] 📃 README.md
- [x] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

react-router-dom 설치됨

## 📄 기타

- 아직 theme가 develop에 머지되지 않아서,
- 네비게이션 마크업 및 스타일링을 포함한 네비게이션 컴포넌트 완성은 다른 이슈로 진행합니다.
- 최대한 작게 커밋을 작성했습니다.



