### PR TITLE
[Feat] 아이콘 + 텍스트 버튼 컴포넌트 생성

### DIFF
--- a/src/components/common/buttons/IconTextButton.tsx
+++ b/src/components/common/buttons/IconTextButton.tsx
@@ -1,0 +1,108 @@
+import { ComponentType, SVGProps } from 'react';
+
+import { css } from '@emotion/react';
+
+import theme from '@/styles/theme';
+
+type IconButtonVariant = 'transparent' | 'dark' | 'light' | 'large';
+
+interface IconTextButtonProps {
+  Icon: ComponentType<SVGProps<SVGAElement>>;
+  variant?: IconButtonVariant;
+  iconPosition?: 'left' | 'right';
+  onClick?: () => void;
+  children: string;
+}
+
+const IconTextButton: React.FC<IconTextButtonProps> = ({
+  Icon,
+  variant = 'transparent',
+  iconPosition = 'right',
+  onClick,
+  children,
+}: IconTextButtonProps) => (
+  <button
+    css={[baseButtonStyle, getVariantStyle(variant)]}
+    onClick={onClick}
+    className={iconPosition}
+  >
+    <Icon />
+    {children}
+  </button>
+);
+
+const baseButtonStyle = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 8px 8px 8px 12px;
+  gap: 4px;
+  font-size: ${theme.fontSizes.xsmall};
+
+  svg {
+    width: ${theme.fontSizes.small};
+    height: ${theme.fontSizes.small};
+  }
+  &.left {
+    flex-direction: row-reverse;
+  }
+`;
+
+const getVariantStyle = (variant: IconButtonVariant) => {
+  switch (variant) {
+    case 'transparent':
+      return css`
+        height: ${theme.fontSizes.small};
+        background-color: transparent;
+        font-size: ${theme.fontSizes.xsmall};
+        font-weight: 500;
+        color: ${theme.colors.white};
+      `;
+    case 'dark':
+      return css`
+        height: ${theme.heights.short};
+        background-color: ${theme.colors.tertiary};
+        font-size: ${theme.fontSizes.small};
+        font-weight: 500;
+        line-height: 14px;
+        color: ${theme.colors.white};
+        border-radius: 20px;
+        padding: 4px 12px;
+        gap: 2px;
+      `;
+    case 'light':
+      return css`
+        height: ${theme.heights.short};
+        background-color: ${theme.colors.white};
+        font-size: ${theme.fontSizes.normal};
+        line-height: 14px;
+        color: ${theme.colors.black};
+        border-radius: 20px;
+        padding: 4px 12px;
+        gap: 2px;
+        svg {
+          width: ${theme.fontSizes.normal};
+          height: ${theme.fontSizes.normal};
+        }
+      `;
+    case 'large':
+      return css`
+        width: 100%;
+        height: ${theme.heights.tall};
+        background-color: ${theme.colors.white};
+        font-size: ${theme.fontSizes.large};
+        font-weight: 500;
+        line-height: 20px;
+        color: ${theme.colors.black};
+        border-radius: 26px;
+        padding: 4px 12px;
+        gap: 6px;
+        svg {
+          width: ${theme.fontSizes.xlarge};
+          height: ${theme.fontSizes.xlarge};
+        }
+      `;
+  }
+};
+
+export default IconTextButton;

--- a/src/components/common/buttons/IconTextButton.tsx
+++ b/src/components/common/buttons/IconTextButton.tsx
@@ -26,8 +26,8 @@ const IconTextButton: React.FC<IconTextButtonProps> = ({
     onClick={onClick}
     className={iconPosition}
   >
-    <Icon />
     {children}
+    <Icon />
   </button>
 );
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
closes #12 
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- isPosition으로 아이콘 위치 설정(디폴트: right)
    - variant로 버튼 스타일 설정(디폴트: transparent)
    - transparent: 자세히보기 >
    - dart: 플리 구독하기 | 플리 구독중
    - light: 수정

- 아이콘은 두 종류 사용합니다. 하단 ✅ **사용하기** 코드에서 import하는 부분 확인해주세요.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

![스크린샷 2024-08-26 오전 12 25 05](https://github.com/user-attachments/assets/94ac1a06-831b-4228-aa53-003434b4f4a8)



## 📄 기타

## ✅ 사용하기

```tsx

// import 로 가져와야 하는 거
import { GoStar, GoStarFill } from 'react-icons/go';  // 별(empty), 별(filled)
import { RiArrowRightSLine, RiPencilLine, RiPlayLargeFill } from 'react-icons/ri'; //  > , 연필, 재생

import IconTextButton from '@/components/common/buttons/IconTextButton';


// 사용 코드
<IconTextButton Icon={RiArrowRightSLine} variant='transparent'>
자세히 보기
</IconTextButton>

<IconTextButton Icon={GoStar} variant='dark'>
플리 구독하기
</IconTextButton>

<IconTextButton Icon={GoStarFill} variant='dark'>
플리 구독중
</IconTextButton>

<IconTextButton Icon={RiPencilLine} variant='light' iconPosition='left'>
쓰기
</IconTextButton>

<IconTextButton Icon={RiPlayLargeFill} variant='large' iconPosition='left'>
Play all
</IconTextButton>



```









