### PR TITLE
[Feat] 헤더 컴포넌트 생성

### DIFF
--- a/src/layouts/layout/Header.tsx
+++ b/src/layouts/layout/Header.tsx
@@ -1,0 +1,59 @@
+import { ComponentType, SVGProps } from 'react';
+
+import { css } from '@emotion/react';
+import { GoChevronLeft } from 'react-icons/go';
+import { useNavigate } from 'react-router-dom';
+
+import theme from '@/styles/theme';
+interface HeaderProps {
+  Icon?: ComponentType<SVGProps<SVGSVGElement>>;
+  children?: React.ReactNode;
+  onBack?: () => void;
+}
+
+const Header: React.FC<HeaderProps> = ({ Icon, children, onBack }: HeaderProps) => {
+  const navigate = useNavigate();
+
+  const handleBack = () => {
+    onBack ? onBack() : navigate(-1);
+  };
+  return (
+    <header css={headerStyle}>
+      <button css={buttonStyle} onClick={handleBack}>
+        <GoChevronLeft />
+      </button>
+      {children && <h1 css={titleStyle}>{children}</h1>}
+      {Icon && (
+        <button css={buttonStyle}>
+          <Icon />
+        </button>
+      )}
+    </header>
+  );
+};
+
+const headerStyle = css`
+  position: relative;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: ${theme.heights.tall};
+  background-color: ${theme.colors.black};
+  padding: 13px 20px 13px 16px;
+`;
+const buttonStyle = css`
+  width: 24px;
+  height: 24px;
+  color: ${theme.colors.white};
+  background-color: transparent;
+  svg {
+    width: 24px;
+    height: 24px;
+`;
+const titleStyle = css`
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+`;
+
+export default Header;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
closes #21 
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 뒤로가기 버튼만 있는 헤더
- 뒤로가기 버튼과 제목이 있는 헤더
- 뒤로가기 버튼과 오른쪽 버튼이 있는 헤더
- onBack 함수에 사용자 정의 뒤로가기 동작을 추가할 수 있음

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)
![스크린샷 2024-08-26 오전 4 19 43](https://github.com/user-attachments/assets/13d1ff63-d03c-4fbe-91df-f84c1df35452)


## 📄 기타

## ✅ **사용 예시**

```tsx

import { RiSettings5Line } from 'react-icons/ri'; // setting 아이콘

import Header from '@/layouts/layout/Header';


// 왼쪽 뒤로가기 버튼과 오른쪽 세팅버튼이 있는 헤더
<Header Icon={RiSettings5Line} />

// 왼쪽 뒤로가기 버튼이 있는 헤더
<Header />

// 왼쪽 뒤로가기 버튼이 있는 헤더
// 뒤로가기 버튼 클릭 시, 사용자가 정의한 뒤로가기 동작 추가 가능
<Header
    onBack={() => {
        console.log('사용자정의 뒤로가기 동작 추가');
    }}
></Header>

// 왼쪽 뒤로가기 버튼과 가운데 제목이 있는 헤더
<Header>설정</Header>



```

