### PR TITLE
[Refactor] Dialog 재생목록 URL로 유튜브 API 호출

### DIFF
--- a/src/api/youtube.ts
+++ b/src/api/youtube.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+import { getVideoId } from '@/utils/getVideoId';
+
 const fetchYoutubeData = axios.create({
   baseURL: 'https://www.googleapis.com/youtube/v3',
   params: {
@@ -7,7 +9,8 @@ const fetchYoutubeData = axios.create({
   },
 });
 
-export const getVideoData = async (videoId: string) => {
+export const getVideoData = async (url: string) => {
+  const videoId = getVideoId(url);
   const response = await fetchYoutubeData.get('/videos', {
     params: {
       part: 'snippet,statistics,player',

--- a/src/components/YouTubePlayerV3.tsx
+++ b/src/components/YouTubePlayerV3.tsx
@@ -4,11 +4,11 @@ import { css } from '@emotion/react';
 import { useVideoData } from '@/hooks/useVideoData';
 
 interface YouTubePlayerProps {
-  videoId: string | null;
+  url: string | null;
 }
 
-const YouTubePlayerV3 = ({ videoId }: YouTubePlayerProps) => {
-  const { data: videoData, isLoading, error } = useVideoData(videoId as string);
+const YouTubePlayerV3 = ({ url }: YouTubePlayerProps) => {
+  const { data: videoData, isLoading, error } = useVideoData(url as string);
 
   if (isLoading) {
     return <div css={loadingStyle}>Loading...</div>;

--- a/src/components/common/modals/Dialog.tsx
+++ b/src/components/common/modals/Dialog.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { css } from '@emotion/react';
 import * as Dialog from '@radix-ui/react-dialog';
 
+import { useVideoData } from '@/hooks/useVideoData';
 import theme from '@/styles/theme';
 
 interface contentType {
@@ -31,6 +32,8 @@ const CustomDialog: React.FC<DialogProps> = ({
   const [youtubeUrl, setYoutubeUrl] = useState('');
   const [thumbnailUrl, setThumbnailUrl] = useState('');
   const [isConfirmDisabled, setIsConfirmDisabled] = useState(true);
+
+  const { data: videoData, isLoading, error } = useVideoData(youtubeUrl as string);
 
   const getModalContent = (type: DialogProps['type']) => {
     switch (type) {
@@ -68,8 +71,11 @@ const CustomDialog: React.FC<DialogProps> = ({
           title: null,
           content: (
             <>
-              {thumbnailUrl && (
+              {/* {thumbnailUrl && (
                 <img src={thumbnailUrl} alt='YouTube Thumbnail' css={thumbnailStyle} />
+              )} */}
+              {videoData && (
+                <img src={videoData.thumbnailUrl} alt='YouTube Thumbnail' css={thumbnailStyle} />
               )}
               <Dialog.Title
                 css={css`
@@ -100,22 +106,26 @@ const CustomDialog: React.FC<DialogProps> = ({
     }
   };
 
-  useEffect(() => {
-    const extractVideoId = (url: string) => {
-      const regex =
-        /(?:youtube\.com\/(?:[^/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?/\s]{11})/;
-      const match = url.match(regex);
-      return match ? match[1] : null;
-    };
+  // useEffect(() => {
+  //   const extractVideoId = (url: string) => {
+  //     const regex =
+  //       /(?:youtube\.com\/(?:[^/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?/\s]{11})/;
+  //     const match = url.match(regex);
+  //     return match ? match[1] : null;
+  //   };
 
-    const videoId = extractVideoId(youtubeUrl);
-    if (videoId) {
-      setThumbnailUrl(`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`);
-    } else {
-      setThumbnailUrl('');
-    }
-    setIsConfirmDisabled(!youtubeUrl.trim());
-  }, [youtubeUrl]);
+  //   const videoId = extractVideoId(youtubeUrl);
+  //   if (videoId) {
+  //     setThumbnailUrl(`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`);
+  //   } else {
+  //     setThumbnailUrl('');
+  //   }
+  //   setIsConfirmDisabled(!youtubeUrl.trim());
+  // }, [youtubeUrl]);
+
+  useEffect(() => {
+    setIsConfirmDisabled(!videoData?.thumbnailUrl.trim());
+  }, [videoData]);
 
   const modalContent = getModalContent(type);
 

--- a/src/hooks/useVideoData.ts
+++ b/src/hooks/useVideoData.ts
@@ -2,17 +2,17 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getVideoData } from '@/api/youtube';
 
-export const useVideoData = (videoId: string) =>
+export const useVideoData = (url: string) =>
   useQuery({
     // 쿼리를 식별하는 고유한 키
     // 배열 형태로, 'video'라는 문자열과 videoId 값으로 구성
     // React Query는 이 키를 사용하여 쿼리 결과를 캐시하고 관리
-    queryKey: ['video', videoId],
+    queryKey: ['videoUrl', url],
     // 실제로 데이터를 가져오는 함수
     // getVideoData 함수를 호출하여 특정 videoId에 대한 데이터를 가져옴
-    queryFn: () => getVideoData(videoId),
+    queryFn: () => getVideoData(url),
     // 쿼리의 실행 여부를 결정
     // videoId가 존재하고 유효한 값일 때만 쿼리가 실행
     // 불필요한 API 호출을 방지하는 데 도움
-    enabled: !!videoId,
+    enabled: !!url,
   });

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,5 @@
-import React from 'react';
-
+import CustomDialog from '@/components/common/modals/Dialog';
 import SelectBox from '@/components/common/SelectBox';
-import YouTubePlayerV3 from '@/components/YouTubePlayerV3';
 import { useAuthStatus } from '@/hooks/useAuthStaus';
 // SelectBox에 들어갈 내용
 const items = [
@@ -14,10 +12,11 @@ const items2 = [
   { value: 'dance', label: '춤' },
   { value: 'mukbang', label: '먹방' },
 ];
-
 const Home = () => {
   const { isLoggedIn, userEmail } = useAuthStatus();
-
+  const handle = () => {
+    console.log('hi');
+  };
   return (
     <div>
       <h1>Logo</h1>
@@ -25,7 +24,7 @@ const Home = () => {
       <p>selectbox 테스트</p>
       <SelectBox items={items} />
       <SelectBox items={items2} />
-
+      <CustomDialog type='videoimageLink' isOpen={true} onClose={handle} />
       <div>
         <h2>인증 상태</h2>
         <p>로그인 상태: {isLoggedIn ? '로그인됨' : '로그인되지 않음'}</p>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import SelectBox from '@/components/common/SelectBox';
+import YouTubePlayerV3 from '@/components/YouTubePlayerV3';
 import { useAuthStatus } from '@/hooks/useAuthStaus';
 // SelectBox에 들어갈 내용
 const items = [


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
closes #81
<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

1. `useVideoData` 커스텀훅 매개변수를 `videoId`에서 `url`로 수정
  - 커스텀훅에서 자체적으로 `videoId` 추출

3. 유튜브API 호출 성공여부에 따른 Dialog 컴포넌트 이미지 표시 및 등록 활성화
  - 기존: url을 통해 유튜브 API 호출이 아닌 이미지만 받아오는 로직
  - 수정: 사용자가 url을 입력하면 유튜브 API를 호출하고, 성공여부에 따라 이미지 표시 및 등록 버튼 활성화


## 수정 사항
일단 기존 코드는 삭제하지 않고 주석처리해놨습니다, 검토 한번 해주시고 정리해주심 될 것 같아요~
1. `useVideoData` 커스텀훅으로 통해 받은 `youtubeUrl`로 API 요청
(**현재 isLoading, Error 처리는 어떻게 보여질지 안 정해진 것 같아 따로 하지 않았습니다, 이는 추가해주심 됩니다 ㅎㅎ**)

<img width="899" alt="image" src="https://github.com/user-attachments/assets/ba2ea7eb-9f04-401e-a17f-93ed301cf7dc">

2. API에서 받은 데이터(`videoData`)가 있을지 썸네일 이미지 출력

<img width="1035" alt="image" src="https://github.com/user-attachments/assets/962a93c2-79d5-4bf5-ad89-a87cb6856c0e">

3. 기존 `videoId` 추출하는 `useEffect` 제거

- 여기서 `setIsConfirmDisabled` 상태는 필요할 것 같아서 아래 이것만 처리하는 `useEffect` 생성
<img width="1148" alt="image" src="https://github.com/user-attachments/assets/d804c136-1565-40f8-a619-66f831dd294f">


## 📸 스크린샷
1. 잘못된 영상 URL 입력 시, 이미지 출력되지않고 등록버튼도 비활성화

<img width="321" alt="image" src="https://github.com/user-attachments/assets/b501f39f-9689-4805-a27f-c7aa0a79e246">

2. API 요청이 가능한 영상 URL 입력 시, 이미지 출력 및 등록버튼 활성화

**(주의) 실존하는 URL이라고 해도, 외부 노출을 막아둔 URL의 경우 API 요청이 실패할 수도 있습니다.**
<img width="303" alt="image" src="https://github.com/user-attachments/assets/e4138086-7217-4879-ac46-000456457fe4">

3. 추가로, `onChange`로 요청을 보내므로 불필요한 요청이 생길 수 있음
- 아래는 한 글자씩 입력하는 경우

<img width="403" alt="image" src="https://github.com/user-attachments/assets/7f0d5ec6-109d-4da1-8696-6fb3ea86a91e">

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

Dialog 컴포넌트를 리팩토링하여 YouTube API 호출에 플레이리스트 URL을 사용하고, 동적 썸네일 표시 및 등록 버튼 활성화를 가능하게 합니다. `useVideoData` 훅을 업데이트하여 URL을 직접 처리하고, 수동으로 비디오 ID를 추출할 필요를 제거합니다.

새로운 기능:
- Dialog 컴포넌트에서 플레이리스트 URL을 사용하여 YouTube API 호출을 가능하게 하여, API 호출 성공에 따라 동적 썸네일 표시 및 등록 버튼 활성화를 허용합니다.

개선 사항:
- `useVideoData` 커스텀 훅을 리팩토링하여 비디오 ID 대신 URL을 받아들이고, API 요청을 위해 내부적으로 비디오 ID를 추출합니다.
- Dialog 컴포넌트에서 URL에서 비디오 ID를 추출하는 이전 로직을 제거하고, 리팩토링된 `useVideoData` 훅을 사용하여 프로세스를 단순화합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the Dialog component to use playlist URLs for YouTube API calls, enabling dynamic thumbnail display and registration button activation. Update the `useVideoData` hook to handle URLs directly, removing the need for manual video ID extraction.

New Features:
- Enable YouTube API calls using playlist URLs in the Dialog component, allowing for dynamic thumbnail display and registration button activation based on API call success.

Enhancements:
- Refactor the `useVideoData` custom hook to accept a URL instead of a video ID, extracting the video ID internally for API requests.
- Remove the previous logic for extracting video IDs from URLs in the Dialog component, simplifying the process by using the refactored `useVideoData` hook.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->