### PR TITLE
[Refactor] MyPlaylist (플립오버 카드) 기능개선

### DIFF
--- a/src/components/mypage/MyPlaylists.tsx
+++ b/src/components/mypage/MyPlaylists.tsx
@@ -13,20 +13,12 @@ interface MyPlaylistsProps {
 }
 
 const MyPlaylists: React.FC<MyPlaylistsProps> = ({ playlists }) => {
-  const [activeFlipCards, setActiveFlipCards] = useState<Set<string>>(new Set());
+  const [activeFlipCard, setActiveFlipCard] = useState<string | null>(null);
   const isToggled = useToggleStore((state) => state.isToggled);
   const toggle = useToggleStore((state) => state.toggle);
 
   const handleFlip = (id: string) => {
-    setActiveFlipCards((prevActive) => {
-      const newActive = new Set(prevActive);
-      if (newActive.has(id)) {
-        newActive.delete(id);
-      } else {
-        newActive.add(id);
-      }
-      return newActive;
-    });
+    setActiveFlipCard((prevActive) => (prevActive === id ? null : id));
   };
   const filteredPlaylists = useMemo(
     () => (isToggled ? playlists.filter((playlist) => playlist.isPublic) : playlists),
@@ -34,7 +26,7 @@ const MyPlaylists: React.FC<MyPlaylistsProps> = ({ playlists }) => {
   );
   // 토글 상태가 변경될 때 모든 카드를 초기 상태로 되돌려 줘
   useEffect(() => {
-    setActiveFlipCards(new Set());
+    setActiveFlipCard(null);
   }, [isToggled]);
   return (
     <div css={wrapperStyle}>
@@ -55,7 +47,7 @@ const MyPlaylists: React.FC<MyPlaylistsProps> = ({ playlists }) => {
           <FlipCard
             key={index}
             id={playlist.playlistId}
-            isFlipped={activeFlipCards.has(playlist.playlistId)}
+            isFlipped={activeFlipCard === playlist.playlistId}
             onFlip={() => handleFlip(playlist.playlistId)}
             title={playlist.title}
             category={playlist.category}


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
closes #83 
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

추가된 기능:
- 다른 카드를 클릭하면 이전에 뒤집혀 있던 카드는 자동으로 앞면으로 돌아가고, 새로 클릭한 카드가 뒷면으로 변경

변경 설명:
- activeFlipCards를 Set 대신 단일 문자열 또는 **null 값을 가지는 `activeFlipCard`로 변경(한 번에 하나의 카드만 뒤집히도록)**
- **`handleFlip` 함수를 수정:** 현재 활성화된 카드가 클릭된 카드와 같으면 null로 설정, 그렇지 않으면 새로 클릭된 카드의 ID로 설정(같은 카드를 다시 클릭했을 때 앞면으로 변경, 다른 카드를 클릭하면 이전에 뒤집혀 있던 카드가 자동으로 앞면으로 변경)
- FlipCard 컴포넌트에 전달되는 **`isFlipped` prop을 `activeFlipCard === playlist.playlistId`로 변경**(현재 활성화된 카드만 뒤집히도록)
## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

https://github.com/user-attachments/assets/3bbf900a-d6d7-4fe8-8ea1-49c645106cf3


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

MyPlaylists 컴포넌트를 리팩토링하여 활성 플립 카드를 추적하는 데 사용되는 Set을 단일 문자열 또는 null 값으로 대체하여 한 번에 하나의 카드만 뒤집을 수 있도록 플립 카드 기능을 향상시킵니다.

개선 사항:
- 한 번에 하나의 카드만 뒤집을 수 있도록 플립 카드 기능을 개선하고, 새 카드를 클릭할 때 이전에 뒤집힌 카드를 자동으로 다시 뒤집습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the MyPlaylists component to enhance the flip card functionality by replacing the Set used for tracking active flip cards with a single string or null value, ensuring only one card can be flipped at a time.

Enhancements:
- Improve the flip card functionality by allowing only one card to be flipped at a time, automatically flipping back the previously flipped card when a new card is clicked.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->