### PR TITLE
[fix] dialog 비활성화 수정

### DIFF
--- a/src/components/common/modals/Dialog.tsx
+++ b/src/components/common/modals/Dialog.tsx
@@ -127,7 +127,7 @@ const CustomDialog: React.FC<DialogProps> = ({
     if (type === 'alertconfirm') {
       setIsConfirmDisabled(false);
     } else {
-      setIsConfirmDisabled(!videoData?.thumbnailUrl.trim());
+      setIsConfirmDisabled(!(videoData?.thumbnailUrl?.trim() ?? ''));
     }
   }, [type, videoData]);
 

--- a/src/components/common/modals/Dialog.tsx
+++ b/src/components/common/modals/Dialog.tsx
@@ -124,8 +124,12 @@ const CustomDialog: React.FC<DialogProps> = ({
   // }, [youtubeUrl]);
 
   useEffect(() => {
-    setIsConfirmDisabled(!videoData?.thumbnailUrl.trim());
-  }, [videoData]);
+    if (type === 'alertconfirm') {
+      setIsConfirmDisabled(false);
+    } else {
+      setIsConfirmDisabled(!videoData?.thumbnailUrl.trim());
+    }
+  }, [type, videoData]);
 
   const modalContent = getModalContent(type);
 

--- a/src/components/common/modals/Dialog.tsx
+++ b/src/components/common/modals/Dialog.tsx
@@ -218,6 +218,7 @@ const buttonStyle = css`
   cursor: pointer;
   padding: 1rem;
   font-size: ${theme.fontSizes.large};
+  transition: color 300ms ease-in;
 
   &:hover {
     color: ${theme.colors.blueHover};


### PR DESCRIPTION
로그아웃에서 나오는 dialog 모달 비활성화 버그 수정

# 🚀 풀 리퀘스트 제안
closes #111 
<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

dialog if문으로 수정하여 로그아웃,삭제모달은 비활성화 되지않음

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)
<img width="489" alt="스크린샷 2024-09-03 오후 12 40 27" src="https://github.com/user-attachments/assets/173753ba-6fa3-4c90-a493-7a6502b7cc4e">

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

로그아웃 시 'alertconfirm' 타입일 때 모달이 활성 상태를 유지하도록 조건을 수정하여 대화 상자 모달 비활성화 문제를 해결합니다.

버그 수정:
- 로그아웃 시 대화 상자 모달이 잘못 비활성화되는 문제를 수정하여 모달이 활성 상태를 유지하도록 조건을 조정합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the dialog modal disabling issue during logout by modifying the condition to keep the modal active when the type is 'alertconfirm'.

Bug Fixes:
- Fix the issue where the dialog modal was incorrectly disabled during logout by adjusting the condition to ensure the modal remains active.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->