### PR TITLE
[feat] 메인에서 플리 클릭시 상세페이지로 이동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,7 +73,7 @@ const router = createBrowserRouter([
               { path: PATH.MYPAGE_ADD_PLAYLIST, element: <PlaylistAdd /> },
             ],
           },
-          { path: PATH.PLAYLIST, element: <PlayListPage /> },
+          { path: `${PATH.PLAYLIST}/:playlistId`, element: <PlayListPage /> },
 
           // { path: '/example', element: <ExamplePage /> }, // Zustand와 TanStack Query 예시 페이지
           { path: PATH.PLAYLIST, element: <PlayListPage /> },

--- a/src/components/home/PlaylistSection.tsx
+++ b/src/components/home/PlaylistSection.tsx
@@ -46,6 +46,10 @@ const PlaylistSection: React.FC<PlaylistSectionProps> = ({ title, playlists }) =
     navigate('/section-list', { state: { title, playlists } });
   };
 
+  const handleThumBoxClick = (playlist: PlaylistModel) => {
+    navigate(`Playlist/${playlist.playlistId}`, { state: { playlist } });
+  };
+
   return (
     <div css={sectionStyle}>
       <div css={headerStyle}>
@@ -76,6 +80,7 @@ const PlaylistSection: React.FC<PlaylistSectionProps> = ({ title, playlists }) =
               likes={playlist.likeCount}
               uploader={playlist.userId}
               listnum={playlist.videoCount}
+              onClick={() => handleThumBoxClick(playlist)}
             />
           </div>
         ))}

--- a/src/components/home/RecentUpdateSection.tsx
+++ b/src/components/home/RecentUpdateSection.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React from 'react';
 
 import { css } from '@emotion/react';
+import { useNavigate } from 'react-router-dom';
 
 import { titleStyle } from './PlaylistSection';
 import ThumBox from '../common/ThumBox';
@@ -11,27 +12,34 @@ interface RecentUpdateSectionProps {
   playlists: PlaylistModel[];
 }
 
-const RecentUpdateSection: React.FC<RecentUpdateSectionProps> = ({ title, playlists }) => (
-  <div css={listStyle}>
-    <h2 css={titleStyle2}>{title}</h2>
-    {playlists.map((playlist) => (
-      <ThumBox
-        key={playlist.playlistId}
-        type='details'
-        thumURL={playlist.thumbnailUrl}
-        title={playlist.title}
-        subtitle={playlist.description}
-        likes={playlist.likeCount}
-        comments={playlist.commentCount}
-        uploader={playlist.userId}
-        update={playlist.updatedAt}
-        listnum={playlist.videoCount}
-      />
-    ))}
-  </div>
-);
+const RecentUpdateSection: React.FC<RecentUpdateSectionProps> = ({ title, playlists }) => {
+  const navigate = useNavigate();
 
-const listStyle = css``;
+  const handleThumBoxClick = (playlist: PlaylistModel) => {
+    navigate(`Playlist/${playlist.playlistId}`, { state: { playlist } });
+  };
+
+  return (
+    <div>
+      <h2 css={titleStyle2}>{title}</h2>
+      {playlists.map((playlist) => (
+        <ThumBox
+          key={playlist.playlistId}
+          type='details'
+          thumURL={playlist.thumbnailUrl}
+          title={playlist.title}
+          subtitle={playlist.description}
+          likes={playlist.likeCount}
+          comments={playlist.commentCount}
+          uploader={playlist.userId}
+          update={playlist.updatedAt}
+          listnum={playlist.videoCount}
+          onClick={() => handleThumBoxClick(playlist)}
+        />
+      ))}
+    </div>
+  );
+};
 
 const titleStyle2 = css`
   ${titleStyle}

--- a/src/components/home/SectionListPage.tsx
+++ b/src/components/home/SectionListPage.tsx
@@ -18,6 +18,12 @@ const SectionListPage: React.FC = () => {
   const navigate = useNavigate();
   const { title, playlists } = location.state as LocationState;
 
+  const handleThumBoxClick = (playlist: PlaylistModel) => {
+    navigate(`/Playlist/${playlist.playlistId}`, {
+      state: { playlist },
+    });
+  };
+
   return (
     <div>
       <Header onBack={() => navigate(-1)} />
@@ -35,6 +41,7 @@ const SectionListPage: React.FC = () => {
             uploader={playlist.userId}
             update={playlist.updatedAt}
             listnum={playlist.videoCount}
+            onClick={() => handleThumBoxClick(playlist)}
           />
         ))}
       </div>

--- a/src/pages/PlayList.tsx
+++ b/src/pages/PlayList.tsx
@@ -5,6 +5,7 @@ import { FaPlay } from 'react-icons/fa';
 import { GoStar, GoStarFill } from 'react-icons/go';
 import { RiPencilLine } from 'react-icons/ri';
 import { VscKebabVertical } from 'react-icons/vsc';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import Button from '@/components/common/buttons/Button';
 import IconButton from '@/components/common/buttons/IconButton';
@@ -16,30 +17,33 @@ import { useToastStore } from '@/store/useToastStore';
 import theme from '@/styles/theme';
 import { PlaylistModel } from '@/types/playlist';
 
-const fetchMyPlaylists = async (): Promise<PlaylistModel[]> => {
-  const response = await fetch('/src/mock/playlists.json');
-  return await response.json();
-};
+// const fetchMyPlaylists = async (): Promise<PlaylistModel[]> => {
+//   const response = await fetch('/src/mock/playlists.json');
+//   return await response.json();
+// };
 
 const PlayListPage = () => {
   const [isStarFilled, setIsStarFilled] = useState(false);
-  const [playlist, setPlaylist] = useState<PlaylistModel | null>(null);
   const showToast = useToastStore((state) => state.showToast);
+  const location = useLocation();
+  const { playlist } = location.state as { playlist: PlaylistModel };
 
-  useEffect(() => {
-    const loadPlaylist = async () => {
-      try {
-        const playlists = await fetchMyPlaylists();
-        if (playlists.length > 0) {
-          setPlaylist(playlists[2]);
-        }
-      } catch (error) {
-        console.error('Failed to load playlist:', error);
-      }
-    };
+  const navigate = useNavigate();
 
-    loadPlaylist();
-  }, []);
+  // useEffect(() => {
+  //   const loadPlaylist = async () => {
+  //     try {
+  //       const playlists = await fetchMyPlaylists();
+  //       if (playlists.length > 0) {
+  //         setPlaylist(playlists[2]);
+  //       }
+  //     } catch (error) {
+  //       console.error('Failed to load playlist:', error);
+  //     }
+  //   };
+
+  //   loadPlaylist();
+  // }, []);
 
   const handleIconButtonClick = () => {
     setIsStarFilled(!isStarFilled);
@@ -54,12 +58,7 @@ const PlayListPage = () => {
 
   return (
     <div css={containerStyle}>
-      <Header
-        Icon={VscKebabVertical}
-        onBack={() => {
-          console.log('사용자정의 뒤로가기 동작 추가');
-        }}
-      />
+      <Header Icon={VscKebabVertical} onBack={() => navigate(-1)} />
       <ThumBoxDetail
         playlist={playlist}
         profileURL='https://img.freepik.com/free-vector/young-man-with-blue-hair_24877-82124.jpg?t=st=1724720053~exp=1724723653~hmac=2deb5619e93e7a773e2d7f182144cc8c65fa620d252c35388c2f3ec5adac104e&w=1480'


### PR DESCRIPTION
메인에서 플리를 클릭하면 해당 플리의 상세페이지로 이동합니다

# 🚀 풀 리퀘스트 제안
closes #114
<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- playlist.tsx 목업데이터 주석처리 후 데이터 전달
- 플레이리스트 클릭시 해당 플리의 상세페이지로 이동

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

React Router의 useNavigate를 사용하여 개선된 라우팅 로직으로, 메인 페이지에서 플레이리스트를 클릭하면 상세 플레이리스트 페이지로 이동을 구현합니다.

새로운 기능:
- 메인 페이지에서 플레이리스트를 클릭할 때 상세 플레이리스트 페이지로 이동할 수 있도록 합니다.

개선 사항:
- 플레이리스트 클릭을 처리하기 위해 React Router의 useNavigate를 사용하여 플레이리스트 내비게이션 로직을 리팩토링합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement navigation from the main page to the detailed playlist page upon clicking a playlist, using React Router's useNavigate for improved routing logic.

New Features:
- Enable navigation from the main page to the detailed playlist page when a playlist is clicked.

Enhancements:
- Refactor the playlist navigation logic to use React Router's useNavigate for handling playlist clicks.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->