### PR TITLE
[Feat] 플레이리스트 메인 페이지에서 유튜브 API를 사용해 동영상 등록

### DIFF
--- a/src/api/endpoints/playlist.ts
+++ b/src/api/endpoints/playlist.ts
@@ -326,15 +326,13 @@ export const addVideoToPlaylist = async (
 
     const playlistRef = doc(db, 'playlists', playlistId);
 
-    // Firestore 문서 업데이트
     await updateDoc(playlistRef, {
-      // 중복 방지, 여러 클라이언트가 동시에 업데이트를 시도해도 데이터 일관성을 유지
+      // 중복 방지, 여러 사용자가 동시에 업데이트를 시도해도 데이터 일관성 유지 가능
       videos: arrayUnion(newVideo),
       videoCount: increment(1),
       updatedAt: new Date().toISOString(),
     });
 
-    console.log('Video added successfully');
     return true;
   } catch (error) {
     console.error('Error adding video to playlist:', error);

--- a/src/api/endpoints/playlist.ts
+++ b/src/api/endpoints/playlist.ts
@@ -13,6 +13,9 @@ import {
   endAt,
   setDoc,
   deleteDoc,
+  updateDoc,
+  arrayUnion,
+  increment,
 } from 'firebase/firestore';
 import { getDownloadURL, ref, uploadString, deleteObject } from 'firebase/storage';
 
@@ -230,52 +233,6 @@ export const getPlaylistsByCategory = async (
   }
 };
 
-export const getPlaylistsByKeyword = async (
-  keyword: string,
-  limitCount: number = 20
-): Promise<PlaylistModel[]> => {
-  try {
-    const keywordLower = keyword.toLowerCase();
-    const keywordUpper = keyword.toLowerCase() + '\uf8ff';
-
-    const playlistsCol = collection(db, 'playlists');
-    const playlistQuery = query(
-      playlistsCol,
-      orderBy('title'),
-      startAt(keywordLower),
-      endAt(keywordUpper),
-      orderBy('createdAt', 'desc'),
-      limit(limitCount)
-    );
-
-    const playlistSnapshot = await getDocs(playlistQuery);
-
-    return playlistSnapshot.docs.map((doc) => {
-      const data = doc.data();
-      return {
-        playlistId: doc.id,
-        userName: data.userName,
-        userId: data.userId,
-        title: data.title,
-        description: data.description,
-        category: data.category,
-        videoCount: data.videoCount,
-        likeCount: data.likeCount,
-        forkCount: data.forkCount,
-        commentCount: data.commentCount,
-        thumbnailUrl: data.thumbnailUrl,
-        isPublic: data.isPublic,
-        createdAt: data.createdAt,
-        updatedAt: data.updatedAt,
-        videos: data.videos,
-      };
-    });
-  } catch (error) {
-    console.error('Error fetching playlists by keyword:', error);
-    return [];
-  }
-};
-
 // 새 플레이리스트 만들기
 export const addPlaylist = async (
   playlistData: PlaylistFormDataModel,
@@ -354,5 +311,33 @@ export const deletePlaylist = async (playlistId: string): Promise<void> => {
   } catch (error) {
     console.error('Error deleting playlist:', error);
     throw error; // 에러를 상위로 전파
+  }
+};
+
+// 플레이리스트에 비디오 추가
+export const addVideoToPlaylist = async (
+  playlistId: string | undefined,
+  newVideo: Video
+): Promise<boolean> => {
+  try {
+    if (!playlistId) {
+      throw new Error('Playlist ID is missing in the URL.');
+    }
+
+    const playlistRef = doc(db, 'playlists', playlistId);
+
+    // Firestore 문서 업데이트
+    await updateDoc(playlistRef, {
+      // 중복 방지, 여러 클라이언트가 동시에 업데이트를 시도해도 데이터 일관성을 유지
+      videos: arrayUnion(newVideo),
+      videoCount: increment(1),
+      updatedAt: new Date().toISOString(),
+    });
+
+    console.log('Video added successfully');
+    return true;
+  } catch (error) {
+    console.error('Error adding video to playlist:', error);
+    return false;
   }
 };

--- a/src/api/endpoints/youtube.ts
+++ b/src/api/endpoints/youtube.ts
@@ -5,7 +5,7 @@ export const getVideoData = async (url: string) => {
   const videoId = getVideoId(url);
   const response = await fetchYoutubeData.get('/videos', {
     params: {
-      part: 'snippet,statistics,player',
+      part: 'snippet,statistics,player,contentDetails',
       id: videoId,
     },
   });
@@ -18,10 +18,11 @@ export const getVideoData = async (url: string) => {
 
   return {
     title: item.snippet.title,
-    channelTitle: item.snippet.channelTitle,
-    channelId: item.snippet.channelId,
+    // channelTitle: item.snippet.channelTitle,
+    // channelId: item.snippet.channelId,
     thumbnailUrl: item.snippet.thumbnails.medium.url,
-    publishedAt: new Date(item.snippet.publishedAt).toLocaleDateString(),
+    duration: item.contentDetails.duration,
+    // publishedAt: new Date(item.snippet.publishedAt).toLocaleDateString(),
   };
 };
 

--- a/src/components/common/VideoCard.tsx
+++ b/src/components/common/VideoCard.tsx
@@ -7,18 +7,26 @@ import Badge from '@/components/common/Badge';
 interface VideoCardProps {
   onClick?: () => void;
   thumbURL?: string;
-  time?: string;
+  duration?: string;
   width?: string;
   height?: string;
   type: 'main' | 'underbar';
 }
 
-const VideoCard: React.FC<VideoCardProps> = ({ onClick, thumbURL, time, type, width, height }) => (
+const VideoCard: React.FC<VideoCardProps> = ({
+  onClick,
+  thumbURL,
+  duration,
+  type,
+  width,
+  height,
+}) => (
   <div css={cardStyle(type, width, height)} onClick={onClick}>
     <img src={thumbURL} alt='Video thumbnail' css={imageStyle} />
-    {type === 'main' && time && <Badge position='corner'>{time}</Badge>}
+    {type === 'main' && duration && <Badge position='corner'>{duration}</Badge>}
   </div>
 );
+
 const cardStyle = (type: 'main' | 'underbar', width?: string, height?: string) => css`
   position: relative;
   cursor: pointer;

--- a/src/components/common/buttons/CommentsButton.tsx
+++ b/src/components/common/buttons/CommentsButton.tsx
@@ -13,7 +13,7 @@ interface CommentsButtonProps {
 const CommentsButton: React.FC<CommentsButtonProps> = ({ playListId, commentCount = 0 }) => {
   const navigate = useNavigate();
 
-  const handleCommentClick = () => navigate(`/${playListId}/comments`);
+  const handleCommentClick = () => navigate(`/comments/${playListId}`);
 
   const formattedCommentCount = formatNumberToK(commentCount);
 

--- a/src/components/common/buttons/IconButton.tsx
+++ b/src/components/common/buttons/IconButton.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, SVGProps } from 'react';
+import { ComponentType, Dispatch, SetStateAction, SVGProps } from 'react';
 
 import { css, SerializedStyles } from '@emotion/react';
 
@@ -6,15 +6,15 @@ import theme from '@/styles/theme';
 interface IconButtonProps {
   Icon: ComponentType<SVGProps<SVGSVGElement>>;
   type?: 'reset' | 'button' | 'submit';
-  onClick?: () => void;
   customStyle?: SerializedStyles;
+  onClick?: () => void;
 }
 
 const IconButton: React.FC<IconButtonProps> = ({
   Icon,
-  onClick,
   type = 'button',
   customStyle,
+  onClick,
 }: IconButtonProps) => (
   <button type={type} css={[iconButtonStyle, customStyle]} onClick={onClick}>
     <Icon />

--- a/src/components/common/modals/Dialog.tsx
+++ b/src/components/common/modals/Dialog.tsx
@@ -21,7 +21,7 @@ interface DialogProps {
   onClose: () => void;
   onConfirm?: () => void;
   onCancel?: () => void;
-  setVideoData: Dispatch<SetStateAction<Partial<Video> | undefined>>;
+  setVideoData?: Dispatch<SetStateAction<Partial<Video> | undefined>>;
 }
 
 const CustomDialog: React.FC<DialogProps> = ({
@@ -40,9 +40,9 @@ const CustomDialog: React.FC<DialogProps> = ({
   const { data: videoData } = useVideoData(youtubeUrl as string);
 
   useEffect(() => {
-    type === 'alertConfirm' ? setIsConfirmDisabled(false) : setIsConfirmDisabled(!videoData);
+    setIsConfirmDisabled(type !== 'alertConfirm' && !videoData);
 
-    if (videoData)
+    if (setVideoData && videoData)
       setVideoData({
         ...videoData,
         videoId: getVideoId(youtubeUrl),

--- a/src/components/common/modals/Dialog.tsx
+++ b/src/components/common/modals/Dialog.tsx
@@ -45,7 +45,6 @@ const CustomDialog: React.FC<DialogProps> = ({
       setVideoData({ ...videoData, videoId: getVideoId(youtubeUrl), videoUrl: youtubeUrl });
   }, [videoData]);
 
-  // console.log(videoData);
   const getModalContent = (type: DialogProps['type']) => {
     switch (type) {
       case 'alertConfirm':

--- a/src/components/common/modals/Dialog.tsx
+++ b/src/components/common/modals/Dialog.tsx
@@ -6,6 +6,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { useVideoData } from '@/hooks/query/useYoutube';
 import theme from '@/styles/theme';
 import { Video } from '@/types/playlist';
+import { formatDurationISOToTime } from '@/utils/formatTime';
 import { getVideoId } from '@/utils/getVideoId';
 
 interface contentType {
@@ -42,7 +43,12 @@ const CustomDialog: React.FC<DialogProps> = ({
     type === 'alertConfirm' ? setIsConfirmDisabled(false) : setIsConfirmDisabled(!videoData);
 
     if (videoData)
-      setVideoData({ ...videoData, videoId: getVideoId(youtubeUrl), videoUrl: youtubeUrl });
+      setVideoData({
+        ...videoData,
+        videoId: getVideoId(youtubeUrl),
+        videoUrl: youtubeUrl,
+        duration: formatDurationISOToTime(videoData.duration),
+      });
   }, [videoData]);
 
   const getModalContent = (type: DialogProps['type']) => {
@@ -80,7 +86,15 @@ const CustomDialog: React.FC<DialogProps> = ({
                   </div>
                 </Dialog.Title>
               ) : (
-                <div css={descriptionStyle}>등록 가능한 영상입니다.</div>
+                <Dialog.Title
+                  css={css`
+                    text-align: left;
+                    width: 100%;
+                  `}
+                >
+                  {videoData.title}
+                  <div css={descriptionStyle}>등록 가능한 영상입니다.</div>
+                </Dialog.Title>
               )}
 
               <input

--- a/src/components/common/modals/Dialog.tsx
+++ b/src/components/common/modals/Dialog.tsx
@@ -33,7 +33,7 @@ const CustomDialog: React.FC<DialogProps> = ({
   const [youtubeUrl, setYoutubeUrl] = useState('');
   const [isConfirmDisabled, setIsConfirmDisabled] = useState(true);
 
-  const { data: videoData, isLoading } = useVideoData(youtubeUrl as string);
+  const { data: videoData } = useVideoData(youtubeUrl as string);
 
   useEffect(() => {
     if (type === 'alertConfirm') {
@@ -61,21 +61,26 @@ const CustomDialog: React.FC<DialogProps> = ({
           title: null,
           content: (
             <>
-              {isLoading ? (
-                <div>불러오는 중!</div>
-              ) : (
-                videoData && (
-                  <img src={videoData.thumbnailUrl} alt='YouTube Thumbnail' css={thumbnailStyle} />
-                )
+              {videoData && (
+                <img src={videoData.thumbnailUrl} alt='YouTube Thumbnail' css={thumbnailStyle} />
               )}
-              <Dialog.Title
-                css={css`
-                  text-align: left;
-                  width: 100%;
-                `}
-              >
-                영상링크
-              </Dialog.Title>
+              {!videoData ? (
+                <Dialog.Title
+                  css={css`
+                    text-align: left;
+                    width: 100%;
+                  `}
+                >
+                  영상링크
+                  <div css={descriptionStyle}>
+                    잘못된 URL 및 공개가 허용되지 않는 영상일 경우 동록할수 없습니다. 등록가능
+                    영상은 썸네일이 표시됩니다.
+                  </div>
+                </Dialog.Title>
+              ) : (
+                <div css={descriptionStyle}>등록 가능한 영상입니다.</div>
+              )}
+
               <input
                 type='text'
                 css={inputStyle}
@@ -222,6 +227,14 @@ const thumbnailStyle = css`
   border-radius: 4px;
   margin-bottom: 10px;
   object-fit: cover;
+`;
+
+const descriptionStyle = css`
+  font-size: ${theme.fontSizes.small};
+  color: ${theme.colors.disabledText};
+  margin-top: 8px;
+  letter-spacing: -0.4px;
+  line-height: 16px;
 `;
 
 export default CustomDialog;

--- a/src/components/mypage/MyProfile.tsx
+++ b/src/components/mypage/MyProfile.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/react';
 import { RiSettings5Line } from 'react-icons/ri'; // setting 아이콘
 import { useNavigate } from 'react-router-dom';
 
-import defaultAvatar from '@/assets/images/default-avatar-woman.svg';
 import Badge from '@/components/common/Badge';
 import { PATH } from '@/constants/path';
 import theme from '@/styles/theme';
@@ -32,7 +31,7 @@ const MyProfile: React.FC<MyProfileProps> = ({ userData }) => {
       <section css={sectionStyle}>
         <div css={bgStyle(hasBadge)}>
           <div css={contentStyle}>
-            <img src={defaultAvatar} alt='profile image' css={photoStyle} />
+            <img src={userData.profileImg} alt='profile image' css={photoStyle} />
             {/* profile image */}
             <div css={profileStyle}>
               <h2>{userData.userName}</h2>

--- a/src/components/playlistdetail/VideoBoxDetail.tsx
+++ b/src/components/playlistdetail/VideoBoxDetail.tsx
@@ -6,7 +6,7 @@ import { GoKebabHorizontal } from 'react-icons/go';
 import VideoCard from '@/components/common/VideoCard';
 import theme from '@/styles/theme';
 import { PlaylistModel } from '@/types/playlist';
-import { formatDurationSecondToTime } from '@/utils/formatTime';
+import { formatDurationISOToTime, formatDurationSecondToTime } from '@/utils/formatTime';
 
 interface VideoBoxDetailProps {
   video: PlaylistModel['videos'][0];
@@ -26,7 +26,6 @@ const VideoBoxDetail: React.FC<VideoBoxDetailProps> = ({
   onClickKebob,
 }) => {
   const { thumbnailUrl, duration, title } = video;
-
   return (
     <div css={containerStyle} onClick={onClick}>
       {type === 'host' && (
@@ -38,7 +37,7 @@ const VideoBoxDetail: React.FC<VideoBoxDetailProps> = ({
           }}
         />
       )}
-      <VideoCard type='main' thumbURL={thumbnailUrl} time={formatDurationSecondToTime(duration)} />
+      <VideoCard type='main' thumbURL={thumbnailUrl} duration={duration} />
       <div css={detailsStyle}>
         <h3 css={titleStyle}>{title}</h3>
         <p css={channelStyle}>{channelName}</p>

--- a/src/components/playlistdetail/thumBoxDetail.tsx
+++ b/src/components/playlistdetail/thumBoxDetail.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 
 import { css } from '@emotion/react';
 
+import defaultProfileImage from '@/assets/images/default-avatar-man.svg';
 import CommentsButton from '@/components/common/buttons/CommentsButton';
 import LikesButton from '@/components/common/buttons/LikesButton';
 import Profile from '@/components/profile/Profile';
@@ -9,6 +10,7 @@ import { useLikeStore } from '@/store/useLikeStore';
 import theme from '@/styles/theme';
 import { PlaylistModel } from '@/types/playlist';
 import { UserModel } from '@/types/user';
+import { formatTimeWithUpdated } from '@/utils/formatDate';
 
 interface ThumBoxDetailProps {
   playlist: PlaylistModel;
@@ -17,15 +19,9 @@ interface ThumBoxDetailProps {
   onClickProfile?: () => void;
 }
 
-const ThumBoxDetail: React.FC<ThumBoxDetailProps> = ({
-  playlist,
-  user,
-  profileURL,
-  onClickProfile,
-}) => {
+const ThumBoxDetail: React.FC<ThumBoxDetailProps> = ({ playlist, user, onClickProfile }) => {
   const {
     playlistId,
-    userId,
     title,
     description,
     updatedAt,
@@ -36,7 +32,7 @@ const ThumBoxDetail: React.FC<ThumBoxDetailProps> = ({
     thumbnailUrl,
   } = playlist;
 
-  const { profileImg, userName } = user;
+  const { profileImg = defaultProfileImage, userName } = user;
 
   const likes = useLikeStore((state) => state.likes);
   const isLiked = useLikeStore((state) => state.isLiked);
@@ -84,7 +80,7 @@ const ThumBoxDetail: React.FC<ThumBoxDetailProps> = ({
       <div css={statsRowStyle}>
         <span css={statsStyle}>동영상 {videoCount}개</span>
         <span css={statsStyle}>포크 {forkCount}회</span>
-        <span css={statsStyle}>{new Date(updatedAt).toLocaleDateString()}</span>
+        <span css={statsStyle}>{formatTimeWithUpdated(updatedAt)} 업데이트</span>
       </div>
       <p css={subtitleStyle}>{description}</p>
     </div>

--- a/src/components/playlistdetail/vedieoBoxDetail.tsx
+++ b/src/components/playlistdetail/vedieoBoxDetail.tsx
@@ -6,6 +6,7 @@ import { GoKebabHorizontal } from 'react-icons/go';
 import VideoCard from '@/components/common/VideoCard';
 import theme from '@/styles/theme';
 import { PlaylistModel } from '@/types/playlist';
+import { formatDurationSecondToTime } from '@/utils/formatTime';
 
 interface VideoBoxDetailProps {
   video: PlaylistModel['videos'][0];
@@ -26,12 +27,6 @@ const VideoBoxDetail: React.FC<VideoBoxDetailProps> = ({
 }) => {
   const { thumbnailUrl, duration, title } = video;
 
-  const formatDuration = (seconds: number): string => {
-    const minutes = Math.floor(seconds / 60);
-    const remainingSeconds = seconds % 60;
-    return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
-  };
-
   return (
     <div css={containerStyle} onClick={onClick}>
       {type === 'host' && (
@@ -43,7 +38,7 @@ const VideoBoxDetail: React.FC<VideoBoxDetailProps> = ({
           }}
         />
       )}
-      <VideoCard type='main' thumbURL={thumbnailUrl} time={formatDuration(duration)} />
+      <VideoCard type='main' thumbURL={thumbnailUrl} time={formatDurationSecondToTime(duration)} />
       <div css={detailsStyle}>
         <h3 css={titleStyle}>{title}</h3>
         <p css={channelStyle}>{channelName}</p>

--- a/src/hooks/useAddVideo.ts
+++ b/src/hooks/useAddVideo.ts
@@ -1,0 +1,9 @@
+// import { useState } from 'react';
+
+// import { useVideoData } from '@/hooks/query/useYoutube';
+
+// export const useAddVideo = () => {
+//   const [youtubeUrl, setYoutubeUrl] = useState('');
+
+//   const { data: videoData, isLoading, error } = useVideoData(youtubeUrl as string);
+// };

--- a/src/hooks/useAddVideo.tsx
+++ b/src/hooks/useAddVideo.tsx
@@ -1,0 +1,3 @@
+export const useAddVideo = () => {
+  const a = 1;
+};

--- a/src/hooks/useAddVideo.tsx
+++ b/src/hooks/useAddVideo.tsx
@@ -1,9 +1,0 @@
-// import { useVideoData } from "@/hooks/query/useYoutube";
-// import { useState } from "react";
-
-// export const useAddVideo = (url) => {
-//   const [youtubeUrl, setYoutubeUrl] = useState('');
-
-//   const { data: videoData, isLoading, error } = useVideoData(url as string);
-
-// };

--- a/src/hooks/useAddVideo.tsx
+++ b/src/hooks/useAddVideo.tsx
@@ -1,3 +1,9 @@
-export const useAddVideo = () => {
-  const a = 1;
-};
+// import { useVideoData } from "@/hooks/query/useYoutube";
+// import { useState } from "react";
+
+// export const useAddVideo = (url) => {
+//   const [youtubeUrl, setYoutubeUrl] = useState('');
+
+//   const { data: videoData, isLoading, error } = useVideoData(url as string);
+
+// };

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -21,6 +21,7 @@ const MyPage = () => {
   const [userData, setUserData] = useState<UserModel | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+
   useEffect(() => {
     const fetchPlaylists = async () => {
       try {

--- a/src/pages/PlaylistEdit.tsx
+++ b/src/pages/PlaylistEdit.tsx
@@ -16,10 +16,10 @@ const PlaylistEdit = () => {
   const { playlist, isLoading, error } = usePlaylistData(playlistId);
 
   const getCategoryValue = (label: string): string => {
-    const category = CATEGORY_OPTIONS.find((option) => option.label === label);
+    const category = CATEGORY_OPTIONS.find((option) => option.value === label);
+
     return category ? category.value : '';
   };
-
   if (isLoading) {
     return <div>Loading...</div>;
   }

--- a/src/pages/PlaylistPage.tsx
+++ b/src/pages/PlaylistPage.tsx
@@ -21,12 +21,12 @@ import { useModalStore } from '@/store/useModalStore';
 import { useToastStore } from '@/store/useToastStore';
 import { useToggleStore } from '@/store/useToggleStore';
 import theme from '@/styles/theme';
-import { PlaylistModel } from '@/types/playlist';
+import { PlaylistModel, Video } from '@/types/playlist';
 import { UserModel } from '@/types/user';
 
 const PlaylistPage: React.FC = () => {
   const { playlistId } = useParams<{ playlistId: string }>(); // URL 파라미터에서 playlistId 추출
-  const [playlist, setPlaylist] = useState<PlaylistModel | null>(null);
+  const [playlist, setPlaylist] = useState<PlaylistModel | null>();
   const [user, setUser] = useState<UserModel | null>(null);
   const isToggled = useToggleStore((state) => state.isToggled);
   const toggle = useToggleStore((state) => state.toggle);
@@ -35,6 +35,8 @@ const PlaylistPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
 
+  const [videoData, setVideoData] = useState<Partial<Video>>(); // 추가추가
+  console.log(videoData);
   const isModalOpen = useModalStore((state) => state.isModalOpen); // 추가추가
   const { openModal, closeModal } = useModalStore(); // 추가추가
 
@@ -208,6 +210,7 @@ const PlaylistPage: React.FC = () => {
           isOpen={isModalOpen}
           onClose={closeModal}
           onConfirm={confirmSignOut}
+          setVideoData={setVideoData}
         />
       )}
     </div>

--- a/src/pages/PlaylistPage.tsx
+++ b/src/pages/PlaylistPage.tsx
@@ -85,6 +85,7 @@ const PlaylistPage: React.FC = () => {
   };
   const handleAddPlaylist = () => {
     // console.log('플레이리스트 링크 추가하는 모달 팝업');
+    console.log('여기에서 파이어스토어로 등록!');
     openModal();
   };
   const confirmSignOut = () => {
@@ -158,15 +159,7 @@ const PlaylistPage: React.FC = () => {
         {playlist.userId === userId ? ( // 여기서 user는 로그인한 사용자
           <IconButton Icon={RiPencilLine} onClick={handlePlaylistEdit} />
         ) : (
-          <>
-            <IconButton Icon={isToggled ? GoStarFill : GoStar} onClick={handleIconButtonClick} />
-            <CustomDialog
-              type='videoLink'
-              isOpen={isModalOpen}
-              onClose={closeModal}
-              onConfirm={confirmSignOut}
-            />
-          </>
+          <IconButton Icon={isToggled ? GoStarFill : GoStar} onClick={handleIconButtonClick} />
         )}
       </div>
       {playlist.videos.length > 0 ? (
@@ -209,6 +202,14 @@ const PlaylistPage: React.FC = () => {
         ]}
         onPlaylistClick={handlePlaylistDelete}
       />
+      {isModalOpen && (
+        <CustomDialog
+          type='videoLink'
+          isOpen={isModalOpen}
+          onClose={closeModal}
+          onConfirm={confirmSignOut}
+        />
+      )}
     </div>
   );
 };

--- a/src/pages/PlaylistPage.tsx
+++ b/src/pages/PlaylistPage.tsx
@@ -23,6 +23,7 @@ import { useToggleStore } from '@/store/useToggleStore';
 import theme from '@/styles/theme';
 import { PlaylistModel, Video } from '@/types/playlist';
 import { UserModel } from '@/types/user';
+import { getUserIdBySession } from '@/utils/user';
 
 const PlaylistPage: React.FC = () => {
   const { playlistId } = useParams<{ playlistId: string }>(); // URL 파라미터에서 playlistId 추출
@@ -41,13 +42,8 @@ const PlaylistPage: React.FC = () => {
   const { openModal, closeModal } = useModalStore(); // 추가추가
 
   const navigate = useNavigate();
-  // 세션 스토리지에서 userSession 문자열을 가져와서 파싱
-  const userSessionStr = sessionStorage.getItem('userSession');
-  if (!userSessionStr) {
-    throw new Error('세션에 유저 ID를 찾을 수 없습니다.');
-  }
-  const userSession = JSON.parse(userSessionStr);
-  const userId = userSession.uid;
+
+  const userId = getUserIdBySession();
 
   useEffect(() => {
     async function fetchPlaylistWithUser() {

--- a/src/pages/PlaylistPage.tsx
+++ b/src/pages/PlaylistPage.tsx
@@ -6,7 +6,6 @@ import { RiPlayLargeFill, RiAddLargeLine, RiPencilLine } from 'react-icons/ri';
 import { useParams, useNavigate } from 'react-router-dom';
 
 import { getPlaylistWithUser, deletePlaylist, addVideoToPlaylist } from '@/api/endpoints/playlist';
-import defaultProfileImage from '@/assets/images/default-avatar-man.svg';
 import Button from '@/components/common/buttons/Button';
 import IconButton from '@/components/common/buttons/IconButton';
 import BottomSheet from '@/components/common/modals/BottomSheet';
@@ -15,7 +14,7 @@ import Spinner from '@/components/common/Spinner';
 import Toast from '@/components/common/Toast';
 import NullBox from '@/components/playlistdetail/nullBox';
 import ThumBoxDetail from '@/components/playlistdetail/thumBoxDetail';
-import VideoBoxDetail from '@/components/playlistdetail/vedieoBoxDetail';
+import VideoBoxDetail from '@/components/playlistdetail/VideoBoxDetail';
 import Header from '@/layouts/layout/Header';
 import { useModalStore } from '@/store/useModalStore';
 import { useToastStore } from '@/store/useToastStore';
@@ -36,6 +35,8 @@ const PlaylistPage: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
 
+  const [refreshTrigger, setRefreshTrigger] = useState(Date()); // 요청할 때의 시간
+
   const [videoData, setVideoData] = useState<Partial<Video>>(); // 추가추가
   const isModalOpen = useModalStore((state) => state.isModalOpen); // 추가추가
   const { openModal, closeModal } = useModalStore(); // 추가추가
@@ -45,7 +46,7 @@ const PlaylistPage: React.FC = () => {
   const userId = getUserIdBySession();
 
   useEffect(() => {
-    async function fetchPlaylistWithUser() {
+    const fetchPlaylistWithUser = async () => {
       if (!playlistId) {
         setError('Playlist ID is missing');
         setIsLoading(false);
@@ -67,10 +68,10 @@ const PlaylistPage: React.FC = () => {
       } finally {
         setIsLoading(false);
       }
-    }
+    };
 
     fetchPlaylistWithUser();
-  }, [playlistId]);
+  }, [playlistId, refreshTrigger]);
 
   const handleIconButtonClick = () => {
     showToast('내 재생목록에 저장되었습니다.');
@@ -81,14 +82,14 @@ const PlaylistPage: React.FC = () => {
     console.log('플레이리스트 수정페이지로 이동');
   };
   const handleAddPlaylist = () => {
-    // console.log('플레이리스트 링크 추가하는 모달 팝업');
     openModal();
   };
   const confirmSignOut = () => {
-    console.log(videoData);
     addVideoToPlaylist(playlistId, videoData as Video);
+    setRefreshTrigger(Date());
     closeModal();
   };
+
   const onClickKebob = () => {
     setIsBottomSheetOpen(true);
   };
@@ -141,7 +142,6 @@ const PlaylistPage: React.FC = () => {
         <ThumBoxDetail
           playlist={playlist}
           user={user}
-          profileURL={user.profileImg || defaultProfileImage}
           onClickProfile={() => console.log('프로필 클릭')}
         />
       )}

--- a/src/pages/PlaylistPage.tsx
+++ b/src/pages/PlaylistPage.tsx
@@ -10,12 +10,14 @@ import defaultProfileImage from '@/assets/images/default-avatar-man.svg';
 import Button from '@/components/common/buttons/Button';
 import IconButton from '@/components/common/buttons/IconButton';
 import BottomSheet from '@/components/common/modals/BottomSheet';
+import CustomDialog from '@/components/common/modals/Dialog';
 import Spinner from '@/components/common/Spinner';
 import Toast from '@/components/common/Toast';
 import NullBox from '@/components/playlistdetail/nullBox';
 import ThumBoxDetail from '@/components/playlistdetail/thumBoxDetail';
 import VideoBoxDetail from '@/components/playlistdetail/vedieoBoxDetail';
 import Header from '@/layouts/layout/Header';
+import { useModalStore } from '@/store/useModalStore';
 import { useToastStore } from '@/store/useToastStore';
 import { useToggleStore } from '@/store/useToggleStore';
 import theme from '@/styles/theme';
@@ -32,6 +34,10 @@ const PlaylistPage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+
+  const isModalOpen = useModalStore((state) => state.isModalOpen); // 추가추가
+  const { openModal, closeModal } = useModalStore(); // 추가추가
+
   const navigate = useNavigate();
   // 세션 스토리지에서 userSession 문자열을 가져와서 파싱
   const userSessionStr = sessionStorage.getItem('userSession');
@@ -78,7 +84,11 @@ const PlaylistPage: React.FC = () => {
     console.log('플레이리스트 수정페이지로 이동');
   };
   const handleAddPlaylist = () => {
-    console.log('플레이리스트 링크 추가하는 모달 팝업');
+    // console.log('플레이리스트 링크 추가하는 모달 팝업');
+    openModal();
+  };
+  const confirmSignOut = () => {
+    closeModal();
   };
   const onClickKebob = () => {
     setIsBottomSheetOpen(true);
@@ -148,7 +158,15 @@ const PlaylistPage: React.FC = () => {
         {playlist.userId === userId ? ( // 여기서 user는 로그인한 사용자
           <IconButton Icon={RiPencilLine} onClick={handlePlaylistEdit} />
         ) : (
-          <IconButton Icon={isToggled ? GoStarFill : GoStar} onClick={handleIconButtonClick} />
+          <>
+            <IconButton Icon={isToggled ? GoStarFill : GoStar} onClick={handleIconButtonClick} />
+            <CustomDialog
+              type='videoLink'
+              isOpen={isModalOpen}
+              onClose={closeModal}
+              onConfirm={confirmSignOut}
+            />
+          </>
         )}
       </div>
       {playlist.videos.length > 0 ? (

--- a/src/pages/PlaylistPage.tsx
+++ b/src/pages/PlaylistPage.tsx
@@ -5,7 +5,7 @@ import { GoKebabHorizontal, GoStar, GoStarFill } from 'react-icons/go';
 import { RiPlayLargeFill, RiAddLargeLine, RiPencilLine } from 'react-icons/ri';
 import { useParams, useNavigate } from 'react-router-dom';
 
-import { getPlaylistWithUser, deletePlaylist } from '@/api/endpoints/playlist';
+import { getPlaylistWithUser, deletePlaylist, addVideoToPlaylist } from '@/api/endpoints/playlist';
 import defaultProfileImage from '@/assets/images/default-avatar-man.svg';
 import Button from '@/components/common/buttons/Button';
 import IconButton from '@/components/common/buttons/IconButton';
@@ -37,7 +37,6 @@ const PlaylistPage: React.FC = () => {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
 
   const [videoData, setVideoData] = useState<Partial<Video>>(); // 추가추가
-  console.log(videoData);
   const isModalOpen = useModalStore((state) => state.isModalOpen); // 추가추가
   const { openModal, closeModal } = useModalStore(); // 추가추가
 
@@ -83,10 +82,11 @@ const PlaylistPage: React.FC = () => {
   };
   const handleAddPlaylist = () => {
     // console.log('플레이리스트 링크 추가하는 모달 팝업');
-    console.log('여기에서 파이어스토어로 등록!');
     openModal();
   };
   const confirmSignOut = () => {
+    console.log(videoData);
+    addVideoToPlaylist(playlistId, videoData as Video);
     closeModal();
   };
   const onClickKebob = () => {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -44,7 +44,7 @@ const Settings = () => {
       </ul>
       {isModalOpen && (
         <CustomDialog
-          type='alertconfirm'
+          type='alertConfirm'
           isOpen={isModalOpen}
           onClose={closeModal}
           onConfirm={confirmSignOut}

--- a/src/types/playlist.d.ts
+++ b/src/types/playlist.d.ts
@@ -1,5 +1,5 @@
-interface Video {
-  videoId: string;
+export interface Video {
+  videoId: string | null; // videoId는 쿼리 파라미터에서 추출 (쿼리 파라미터는 존재하지 않으면 null)
   videoUrl: string;
   title: string;
   thumbnailUrl: string;

--- a/src/types/playlist.d.ts
+++ b/src/types/playlist.d.ts
@@ -3,7 +3,7 @@ export interface Video {
   videoUrl: string;
   title: string;
   thumbnailUrl: string;
-  duration: number;
+  duration: string;
 }
 export interface PlaylistFormDataModel {
   title: string;

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -7,6 +7,10 @@ export const formatDurationSecondToTime = (seconds: number): string => {
 
 // ISO 8601(PT5M42S) -> 00:00:00
 export const formatDurationISOToTime = (isoDuration: string): string => {
+  if (!/^PT(\d+H)?(\d+M)?(\d+S)?$/.test(isoDuration)) {
+    throw new Error('Invalid ISO 8601 duration format');
+  }
+
   const match = isoDuration.match(/PT(\d+H)?(\d+M)?(\d+S)?/);
 
   // 타입 가드

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -11,12 +11,20 @@ export const formatDurationISOToTime = (isoDuration: string): string => {
 
   // 타입 가드
   if (!match) {
-    return '0:00:00';
+    return '00:00';
   }
 
-  const hours = match[1] ? match[1].slice(0, -1) : '0';
-  const minutes = match[2] ? match[2].slice(0, -1) : '0';
-  const seconds = match[3] ? match[3].slice(0, -1) : '0';
+  const hours = parseInt(match[1]?.slice(0, -1) || '0');
+  const minutes = parseInt(match[2]?.slice(0, -1) || '0');
+  const seconds = parseInt(match[3]?.slice(0, -1) || '0');
 
-  return `${hours}:${minutes}:${seconds}`;
+  const paddedHours = hours.toString().padStart(2, '0');
+  const paddedMinutes = minutes.toString().padStart(2, '0');
+  const paddedSeconds = seconds.toString().padStart(2, '0');
+
+  if (hours > 0) {
+    return `${paddedHours}:${paddedMinutes}:${paddedSeconds}`;
+  } else {
+    return `${paddedMinutes}:${paddedSeconds}`;
+  }
 };

--- a/src/utils/formatTime.ts
+++ b/src/utils/formatTime.ts
@@ -1,0 +1,22 @@
+// 1000 -> 00:00
+export const formatDurationSecondToTime = (seconds: number): string => {
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
+};
+
+// ISO 8601(PT5M42S) -> 00:00:00
+export const formatDurationISOToTime = (isoDuration: string): string => {
+  const match = isoDuration.match(/PT(\d+H)?(\d+M)?(\d+S)?/);
+
+  // 타입 가드
+  if (!match) {
+    return '0:00:00';
+  }
+
+  const hours = match[1] ? match[1].slice(0, -1) : '0';
+  const minutes = match[2] ? match[2].slice(0, -1) : '0';
+  const seconds = match[3] ? match[3].slice(0, -1) : '0';
+
+  return `${hours}:${minutes}:${seconds}`;
+};

--- a/src/utils/getVideoId.ts
+++ b/src/utils/getVideoId.ts
@@ -1,4 +1,4 @@
-export const getVideoId = (url: string): string | null => {
+export const getVideoId = (url: string): string | null | undefined => {
   // URL 객체를 생성
   const parsedUrl = new URL(url);
   // URLSearchParams 객체를 통해 쿼리 파라미터를 가져옴

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -1,6 +1,11 @@
 // 사용자 세션 가져오기
 export const getUserIdBySession = () => {
-  const value = sessionStorage.getItem('userSession');
-  const userSession = value ? JSON.parse(value) : null;
+  const userSessionObject = sessionStorage.getItem('userSession');
+
+  if (!userSessionObject) {
+    throw new Error('세션에 유저 ID를 찾을 수 없습니다.');
+  }
+
+  const userSession = userSessionObject ? JSON.parse(userSessionObject) : null;
   return userSession?.uid;
 };


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
closes #124
<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

플레이리스트 메인 페이지에서 유튜브 API를 사용해 동영상 등록

- 동영상 등록 모달 구현
- 모달 입력 시, 유튜브 API 연결
- 영상 등록 시, 파이어스토어에 등록
- 등록 후, 현재 플레이리스트에 새로운 동영상이 보일 수 있게 재업데이트
- 기존 `Playlist`에서 구현한 수정, 삭제 기능 브런치와 충돌 해결 후 병합한 PR

## 📸 스크린샷

(등록 모달의 경우, 스크린샷에서 보이지 않습니다..)

https://github.com/user-attachments/assets/b6c4256b-81cd-4106-9880-d59465cdcd25


수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

YouTube API를 사용하여 재생목록 메인 페이지에 비디오를 등록하는 기능을 추가하고, 비디오 입력 및 재생목록 업데이트를 위한 모달 대화 상자를 포함합니다. 비디오 지속 시간 형식을 개선하고 코드의 일관성과 유지 보수성을 향상시키기 위해 리팩토링합니다.

새로운 기능:
- YouTube API를 사용하여 재생목록 메인 페이지에서 비디오 등록을 구현하여 사용자가 재생목록에 비디오를 추가할 수 있도록 합니다.

개선 사항:
- 비디오 등록을 위한 모달 대화 상자를 추가하여 YouTube API와 연결하고 새로운 비디오로 재생목록을 업데이트합니다.
- ISO 8601 형식의 비디오 지속 시간을 읽기 쉬운 시간 형식으로 변환하는 유틸리티 함수를 도입합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add functionality to register videos on the playlist main page using the YouTube API, including a modal dialog for video input and playlist updates. Enhance video duration formatting and refactor code to improve consistency and maintainability.

New Features:
- Implement video registration on the playlist main page using the YouTube API, allowing users to add videos to their playlists.

Enhancements:
- Add a modal dialog for video registration, which connects to the YouTube API and updates the playlist with new videos.
- Introduce utility functions for formatting video durations from ISO 8601 format to a readable time format.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->