### PR TITLE
[Feat] 내 댓글 삭제 기능 구현

### DIFF
--- a/src/api/endpoints/comment.ts
+++ b/src/api/endpoints/comment.ts
@@ -42,7 +42,6 @@ export const getPlaylistComments = async (
         userName: data.userName,
         content: data.content,
         createdAt: data.createdAt,
-        updatedAt: data.updatedAt,
       };
     });
   } catch (error) {

--- a/src/components/comment/CommentBox.tsx
+++ b/src/components/comment/CommentBox.tsx
@@ -1,23 +1,46 @@
 import React, { useEffect, useState } from 'react';
 
 import { css } from '@emotion/react';
+import { doc, deleteDoc } from 'firebase/firestore';
 import { RiCloseFill } from 'react-icons/ri';
 
+import { db } from '@/api';
 import defaultImg from '@/assets/images/default-avatar-man.svg';
+import Toast from '@/components/common/Toast';
+import { useToastStore } from '@/store/useToastStore';
 import theme from '@/styles/theme';
 import { Comment } from '@/types/playlist';
+import { formatTimeWithUpdated } from '@/utils/formatDate';
 import { getUserIdBySession } from '@/utils/user';
-
-const CommentBox: React.FC<Comment> = ({
-  profileImg,
-  userName,
-  content,
-  createdAt,
-  userId: curUserId,
-}: Comment) => {
+interface CommentBoxProps extends Comment {
+  comments: Comment;
+  setComments: React.Dispatch<React.SetStateAction<Comment[]>>;
+}
+const CommentBox: React.FC<CommentBoxProps> = ({ comments, setComments }: CommentBoxProps) => {
   const [commentUserId, setCommentUserId] = useState<string | null>(null);
-  const handleDelBtnClick = () => {
-    console.log('delete!');
+  const { showToast } = useToastStore();
+
+  const handleDelBtnClick = async () => {
+    if (!comments.commentId) {
+      console.error('commentId가 없습니다.');
+      return;
+    }
+    try {
+      if (commentUserId === comments.userId) {
+        const commentRef = doc(db, 'comments', comments.commentId);
+        await deleteDoc(commentRef);
+
+        showToast('댓글이 삭제되었습니다');
+      } else {
+        console.log('삭제 권한이 없습니다.');
+      }
+    } catch (error) {
+      console.error('댓글 삭제 중 오류 발생:', error);
+    }
+
+    setComments((prevComments) =>
+      prevComments.filter((comment) => comment.commentId !== comments.commentId)
+    );
   };
 
   useEffect(() => {
@@ -29,18 +52,19 @@ const CommentBox: React.FC<Comment> = ({
     <>
       <div css={CommentListStyle}>
         <div>
-          <img src={profileImg || defaultImg} alt='미니 썸네일' />
+          <img src={comments.profileImg || defaultImg} alt='미니 썸네일' />
           <div>
-            <h1>{userName}</h1>
-            <h2>{createdAt}</h2>
-            <h3>{content}</h3>
+            <h1>{comments.userName}</h1>
+            <h2>{formatTimeWithUpdated(comments.createdAt)}</h2>
+            <h3>{comments.content}</h3>
           </div>
         </div>
-        {commentUserId === curUserId && (
+        {commentUserId === comments.userId && (
           <RiCloseFill css={deleteIconStyle} onClick={handleDelBtnClick} />
         )}
       </div>
       <hr css={CommentHorizonSytle} />
+      <Toast />
     </>
   );
 };

--- a/src/components/comment/CommentBox.tsx
+++ b/src/components/comment/CommentBox.tsx
@@ -95,7 +95,10 @@ const CommentListStyle = css`
 `;
 
 const deleteIconStyle = css`
+  display: flex;
   cursor: pointer;
+  width: 20px;
+  height: 20px;
 `;
 
 const CommentHorizonSytle = css`

--- a/src/components/comment/CommentBox.tsx
+++ b/src/components/comment/CommentBox.tsx
@@ -1,26 +1,54 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { css } from '@emotion/react';
+import { RiCloseFill } from 'react-icons/ri';
 
 import defaultImg from '@/assets/images/default-avatar-man.svg';
 import theme from '@/styles/theme';
 import { Comment } from '@/types/playlist';
-const CommentBox: React.FC<Comment> = ({ profileImg, userName, content, createdAt }: Comment) => (
-  <div css={CommentListStyle}>
-    <div>
-      <img src={profileImg || defaultImg} alt='미니 썸네일' />
-      <div>
-        <h1>{userName}</h1>
-        <h2>{createdAt}</h2>
-        <h3>{content}</h3>
+import { getUserIdBySession } from '@/utils/user';
+
+const CommentBox: React.FC<Comment> = ({
+  profileImg,
+  userName,
+  content,
+  createdAt,
+  userId: curUserId,
+}: Comment) => {
+  const [commentUserId, setCommentUserId] = useState<string | null>(null);
+  const handleDelBtnClick = () => {
+    console.log('delete!');
+  };
+
+  useEffect(() => {
+    const uid = getUserIdBySession();
+    setCommentUserId(uid);
+  }, []);
+
+  return (
+    <>
+      <div css={CommentListStyle}>
+        <div>
+          <img src={profileImg || defaultImg} alt='미니 썸네일' />
+          <div>
+            <h1>{userName}</h1>
+            <h2>{createdAt}</h2>
+            <h3>{content}</h3>
+          </div>
+        </div>
+        {commentUserId === curUserId && (
+          <RiCloseFill css={deleteIconStyle} onClick={handleDelBtnClick} />
+        )}
       </div>
-    </div>
-  </div>
-);
+      <hr css={CommentHorizonSytle} />
+    </>
+  );
+};
 
 const CommentListStyle = css`
   margin: 10px 0;
   display: flex;
+  justify-content: space-between;
 
   div {
     display: flex;
@@ -66,4 +94,14 @@ const CommentListStyle = css`
   }
 `;
 
+const deleteIconStyle = css`
+  cursor: pointer;
+`;
+
+const CommentHorizonSytle = css`
+  border: 0;
+  height: 1px;
+  background-color: ${theme.colors.tertiary};
+  margin: 10px 0;
+`;
 export default CommentBox;

--- a/src/hooks/query/useComments.ts
+++ b/src/hooks/query/useComments.ts
@@ -1,8 +1,7 @@
-import { useQueries, useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
 import { getPlaylistComments } from '@/api/endpoints/comment';
 import { QUERY_KEYS } from '@/constants/queryKey';
-import { PlaylistModel } from '@/types/playlist';
 
 const defaultOptions = {
   staleTime: 5 * 60 * 1000, // 기본 5분

--- a/src/pages/CommentList.tsx
+++ b/src/pages/CommentList.tsx
@@ -83,6 +83,8 @@ const CommentList = () => {
             userName={comment.userName}
             content={comment.content}
             createdAt={formatTimeWithUpdated(comment.createdAt)}
+            comments={comment}
+            setComments={setComments}
           />
         ))}
       </div>

--- a/src/pages/CommentList.tsx
+++ b/src/pages/CommentList.tsx
@@ -83,7 +83,6 @@ const CommentList = () => {
             userName={comment.userName}
             content={comment.content}
             createdAt={formatTimeWithUpdated(comment.createdAt)}
-            updatedAt={comment.updatedAt}
           />
         ))}
       </div>

--- a/src/types/playlist.d.ts
+++ b/src/types/playlist.d.ts
@@ -28,7 +28,7 @@ export interface PlaylistModel extends PlaylistFormDataModel {
 }
 
 export interface Comment {
-  commentId?: string;
+  commentId?: string | undefined;
   playlistId?: string;
   profileImg: string;
   userId?: string;

--- a/src/types/playlist.d.ts
+++ b/src/types/playlist.d.ts
@@ -35,5 +35,4 @@ export interface Comment {
   userName: string;
   content: string;
   createdAt: string;
-  updatedAt?: string;
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 특정 플레이리스트의 댓글 중, 자신의 댓글을 삭제할 수 있는 기능을 구현하였습니다.
- 서버와 클라이언트에서 동시에 삭제되도록 구현하였습니다.

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

![내 댓글 삭제](https://github.com/user-attachments/assets/c7961dc3-ed46-45a2-96f9-e80452a6b88e)


## 📄 기타

- 삭제버튼 누르면 middle 모달창을 띄워야하는데 사용법을 잘 모르겠어서 토스트로 대체했습니다. 🙃
- 댓글 목록 페이지 내 "댓글 수"에 현재 댓글 수 연동하는 작업 남았습니다.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

사용자가 재생 목록에 대한 자신의 댓글을 삭제할 수 있는 기능을 도입하고, 서버와 클라이언트 간의 업데이트를 동기화합니다. 성공적으로 삭제되었을 때 토스트 알림을 추가하여 사용자 피드백을 향상시킵니다.

새로운 기능:
- 사용자가 특정 재생 목록에 대한 자신의 댓글을 삭제할 수 있는 기능을 구현하고, 변경 사항이 서버와 클라이언트 모두에 반영됩니다.

향상된 기능:
- 사용자의 댓글이 성공적으로 삭제되었을 때 이를 알리는 토스트 알림을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a feature allowing users to delete their own comments on playlists, with updates synchronized between the server and client. Enhance user feedback by adding a toast notification upon successful deletion.

New Features:
- Implement the ability for users to delete their own comments on a specific playlist, with changes reflected on both the server and client.

Enhancements:
- Add a toast notification to inform users when their comment has been successfully deleted.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->