### PR TITLE
[feat] 기존 댓글 카운트, 댓글 작성시 카운트 +1

### DIFF
--- a/src/api/endpoints/playlist.ts
+++ b/src/api/endpoints/playlist.ts
@@ -347,7 +347,12 @@ export const getPlaylistById = async (playlistId: string): Promise<PlaylistModel
       throw new Error(`Playlist with ID ${playlistId} not found`);
     }
 
-    return playlistDoc.data() as PlaylistModel;
+    const playlistData = playlistDoc.data();
+
+    return {
+      ...playlistData,
+      commentCount: playlistData?.commentCount ?? 0,
+    } as PlaylistModel;
   } catch (error) {
     console.error(`Error fetching playlist ${playlistId}:`, error);
     throw error;

--- a/src/pages/CommentList.tsx
+++ b/src/pages/CommentList.tsx
@@ -46,10 +46,6 @@ const CommentList = () => {
       setComments(commentsData);
     }
 
-    if (error) {
-      console.error('Failed to fetch comments:', error);
-    }
-
     async function fetchPlaylistData() {
       if (playlistId) {
         try {
@@ -69,14 +65,14 @@ const CommentList = () => {
   useEffect(() => {
     if (toastMessage) {
       showToast(toastMessage);
-      navigate(location.pathname, { replace: true }); // URL을 변경하지 않고 state만 제거
+      navigate(location.pathname, { replace: true });
     }
   }, [toastMessage, showToast, navigate, location.pathname]);
 
   useEffect(() => {
     if (refetchComments) {
       refetch(); // 댓글을 새로 불러옴
-      navigate(location.pathname, { replace: true }); // state를 초기화
+      navigate(location.pathname, { replace: true });
     }
   }, [refetchComments, refetch, navigate, location.pathname]);
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
closes #147 
<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 플레이리스트를 가져올때 댓글수 가져오기
- 댓글 작성시 기존 댓글에서 카운트 +1
- 댓글 작성시 기존 commentid 안들어가있어서 추가

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

https://github.com/user-attachments/assets/219f0a82-d920-4aea-8daf-bf53798f8990

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

플레이리스트와 함께 댓글 수를 가져오고 새 댓글이 추가될 때 댓글 수를 증가시킴으로써 댓글 시스템을 향상시킵니다. 댓글 목록 구성 요소에서 오류 처리를 단순화합니다.

새로운 기능:
- 플레이리스트를 가져올 때 댓글 수를 검색하는 기능을 구현합니다.

개선 사항:
- 관련된 플레이리스트의 댓글 수를 증가시키도록 댓글 추가 프로세스를 업데이트합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the comment system by retrieving the comment count with playlists and incrementing the count when a new comment is added. Simplify error handling in the comment list component.

New Features:
- Implement functionality to retrieve the comment count when fetching a playlist.

Enhancements:
- Update the comment addition process to increment the comment count on the associated playlist.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->