### PR TITLE
Revert "[feat] 기존 댓글 카운트, 댓글 작성시 카운트 +1"

### DIFF
--- a/src/api/endpoints/comment.ts
+++ b/src/api/endpoints/comment.ts
@@ -7,9 +7,6 @@ import {
   orderBy,
   limit,
   addDoc,
-  increment,
-  updateDoc,
-  doc,
 } from 'firebase/firestore';
 
 import { app } from '@/api'; // Firebase 앱 초기화 파일
@@ -64,7 +61,7 @@ export const addComment = async (
   try {
     const commentsRef = collection(db, 'comments');
 
-    const docRef = await addDoc(commentsRef, {
+    const newComment = {
       playlistId,
       userId,
       userName,
@@ -72,17 +69,10 @@ export const addComment = async (
       content,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
-    });
+    };
 
-    const commentId = docRef.id;
-    await updateDoc(docRef, { commentId });
-
-    const playlistRef = doc(db, 'playlists', playlistId);
-    await updateDoc(playlistRef, {
-      commentCount: increment(1),
-    });
-
-    return commentId;
+    const docRef = await addDoc(commentsRef, newComment);
+    return docRef.id; // 댓글 ID 반환
   } catch (error) {
     console.error('Error adding comment:', error);
     throw new Error('댓글 추가에 실패했습니다.');

--- a/src/api/endpoints/playlist.ts
+++ b/src/api/endpoints/playlist.ts
@@ -347,12 +347,7 @@ export const getPlaylistById = async (playlistId: string): Promise<PlaylistModel
       throw new Error(`Playlist with ID ${playlistId} not found`);
     }
 
-    const playlistData = playlistDoc.data();
-
-    return {
-      ...playlistData,
-      commentCount: playlistData?.commentCount ?? 0,
-    } as PlaylistModel;
+    return playlistDoc.data() as PlaylistModel;
   } catch (error) {
     console.error(`Error fetching playlist ${playlistId}:`, error);
     throw error;

--- a/src/pages/CommentList.tsx
+++ b/src/pages/CommentList.tsx
@@ -46,6 +46,10 @@ const CommentList = () => {
       setComments(commentsData);
     }
 
+    if (error) {
+      console.error('Failed to fetch comments:', error);
+    }
+
     async function fetchPlaylistData() {
       if (playlistId) {
         try {
@@ -65,14 +69,14 @@ const CommentList = () => {
   useEffect(() => {
     if (toastMessage) {
       showToast(toastMessage);
-      navigate(location.pathname, { replace: true });
+      navigate(location.pathname, { replace: true }); // URL을 변경하지 않고 state만 제거
     }
   }, [toastMessage, showToast, navigate, location.pathname]);
 
   useEffect(() => {
     if (refetchComments) {
       refetch(); // 댓글을 새로 불러옴
-      navigate(location.pathname, { replace: true });
+      navigate(location.pathname, { replace: true }); // state를 초기화
     }
   }, [refetchComments, refetch, navigate, location.pathname]);
 


### PR DESCRIPTION
Reverts Dev-FE-1/ToyProject_3_Team2#150

추가 필요한 커밋을 위한 PR 되돌리기

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

새로운 댓글이 추가될 때 재생 목록에서 댓글 수를 증가시키는 기능을 되돌리고, 댓글 수를 업데이트하지 않고 댓글을 추가하는 이전 로직을 복원합니다.

개선 사항:
- 새로운 댓글이 추가될 때 재생 목록 문서에서 댓글 수를 업데이트하는 로직을 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revert the feature that incremented the comment count in the playlist when a new comment was added, restoring the previous logic for adding comments without updating the comment count.

Enhancements:
- Remove the logic for updating the comment count in the playlist document when a new comment is added.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->