### PR TITLE
[Feat] 홈에서 최신 업데이트 플리 무한스크롤 기능

### DIFF
--- a/src/components/page/home/RecentUpdateList.tsx
+++ b/src/components/page/home/RecentUpdateList.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { css } from '@emotion/react';
 import { useNavigate } from 'react-router-dom';
 
+import Spinner from '@/components/common/Spinner';
 import ThumbNailBox from '@/components/common/ThumbNailBox';
 import useInfiniteScroll from '@/hooks/useInfiniteScroll';
 import theme from '@/styles/theme';
@@ -16,18 +17,42 @@ interface RecentUpdateListProps {
 
 const RecentUpdateList: React.FC<RecentUpdateListProps> = ({ title, playlists }) => {
   const navigate = useNavigate();
-  const [visiblePlaylists, setVisiblePlaylists] = useState<PlaylistModel[]>(playlists.slice(0, 10)); // 처음 10개의 항목만 표시
+  const [visiblePlaylists, setVisiblePlaylists] = useState<PlaylistModel[]>([]); // 초기값을 빈 배열로 설정
   const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isFirstLoadComplete, setIsFirstLoadComplete] = useState(false);
 
   const loadMoreItems = () => {
-    console.log('Load more items');
-    const nextPage = page + 1;
-    const newVisiblePlaylists = playlists.slice(0, nextPage * 5); // 다음 10개의 항목을 가져옴
-    setVisiblePlaylists(newVisiblePlaylists);
-    setPage(nextPage);
+    if (isLoading || !hasMore) return;
+
+    setIsLoading(true);
+    setTimeout(() => {
+      console.log('Load more items');
+      const nextPage = page + 1;
+      const newVisiblePlaylists = playlists.slice(0, nextPage * 5); // 다음 5개의 항목을 가져옴
+      setVisiblePlaylists(newVisiblePlaylists);
+      setPage(nextPage);
+      setIsLoading(false);
+
+      // 모든 데이터를 로드했으면 더 이상 불러오지 않도록 무한 호출 방지
+      if (newVisiblePlaylists.length >= playlists.length) {
+        setHasMore(false);
+      }
+    }, 1000); // 데이터 불러오는 속도가 너무 빨라서 1초 딜레이
   };
 
-  const targetRef = useInfiniteScroll(loadMoreItems);
+  const targetRef = useInfiniteScroll(() => {
+    if (isFirstLoadComplete) {
+      loadMoreItems();
+    }
+  }, hasMore);
+
+  // 첫 로딩시 데이터 가져오기
+  useEffect(() => {
+    setVisiblePlaylists(playlists.slice(0, 5)); // 처음 5개 데이터를 불러오기
+    setIsFirstLoadComplete(true); // 첫 로드가 끝났음을 표시
+  }, [playlists]);
 
   return (
     <div>
@@ -48,8 +73,16 @@ const RecentUpdateList: React.FC<RecentUpdateListProps> = ({ title, playlists })
         </div>
       ))}
 
+      {isLoading && (
+        <div css={spinnerStyle}>
+          <Spinner />
+        </div>
+      )}
+
       {/* 무한 스크롤 트리거 요소 */}
-      <div ref={targetRef} style={{ height: '20px', backgroundColor: 'transparent' }} />
+      {hasMore && (
+        <div ref={targetRef} style={{ height: '20px', backgroundColor: 'transparent' }} />
+      )}
     </div>
   );
 };
@@ -60,6 +93,12 @@ const titleStyle = css`
   font-size: ${theme.fontSizes.normal};
   font-weight: 700;
   margin-left: 1rem;
+`;
+
+const spinnerStyle = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 export default RecentUpdateList;

--- a/src/components/page/home/RecentUpdateList.tsx
+++ b/src/components/page/home/RecentUpdateList.tsx
@@ -1,7 +1,10 @@
+import { useState } from 'react';
+
 import { css } from '@emotion/react';
 import { useNavigate } from 'react-router-dom';
 
 import ThumbNailBox from '@/components/common/ThumbNailBox';
+import useInfiniteScroll from '@/hooks/useInfiniteScroll';
 import theme from '@/styles/theme';
 import { PlaylistModel } from '@/types/playlist';
 import { formatTimeWithUpdated } from '@/utils/formatDate';
@@ -13,11 +16,23 @@ interface RecentUpdateListProps {
 
 const RecentUpdateList: React.FC<RecentUpdateListProps> = ({ title, playlists }) => {
   const navigate = useNavigate();
+  const [visiblePlaylists, setVisiblePlaylists] = useState<PlaylistModel[]>(playlists.slice(0, 10)); // 처음 10개의 항목만 표시
+  const [page, setPage] = useState(1);
+
+  const loadMoreItems = () => {
+    console.log('Load more items');
+    const nextPage = page + 1;
+    const newVisiblePlaylists = playlists.slice(0, nextPage * 5); // 다음 10개의 항목을 가져옴
+    setVisiblePlaylists(newVisiblePlaylists);
+    setPage(nextPage);
+  };
+
+  const targetRef = useInfiniteScroll(loadMoreItems);
 
   return (
     <div>
       <h2 css={titleStyle}>{title}</h2>
-      {playlists.map((playlist) => (
+      {visiblePlaylists.map((playlist) => (
         <div key={playlist.playlistId} onClick={() => navigate(`playlist/${playlist.playlistId}`)}>
           <ThumbNailBox
             type='details'
@@ -32,6 +47,9 @@ const RecentUpdateList: React.FC<RecentUpdateListProps> = ({ title, playlists })
           />
         </div>
       ))}
+
+      {/* 무한 스크롤 트리거 요소 */}
+      <div ref={targetRef} style={{ height: '20px', backgroundColor: 'transparent' }} />
     </div>
   );
 };

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+function useInfiniteScroll(onIntersect) {
+  const ref = useRef(null);
+
+  const handleIntersect = useCallback(
+    ([entry], observer) => {
+      if (entry.isIntersecting) {
+        observer.unobserve(entry.target);
+        onIntersect(entry, observer);
+      }
+    },
+    [onIntersect]
+  );
+
+  /*컴포넌트 렌더가 완료됨에 따라 observer가 생성되어야 하므로 useEffect를 활용해야 한다. 
+  또한 target이 생성되기 전에 observe를 시작할 수 없으므로 조건문을 넣어줬다.*/
+
+  useEffect(() => {
+    let observer;
+    if (ref.current) {
+      // 관찰 대상이 존재하는 체크한다.
+      observer = new IntersectionObserver(handleIntersect, { threshold: 0.6 }); // 관찰 대상이 존재한면 관찰자를 생성한다.
+      observer.observe(ref.current); // 관찰자에게 타켓을 지정해준다.
+    }
+    return () => observer && observer.disconnect();
+  }, [ref, handleIntersect]);
+
+  return ref;
+}
+
+export default useInfiniteScroll;

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,16 +1,16 @@
 import { useCallback, useEffect, useRef } from 'react';
 
-function useInfiniteScroll(onIntersect) {
+function useInfiniteScroll(onIntersect, hasMore) {
   const ref = useRef(null);
 
   const handleIntersect = useCallback(
     ([entry], observer) => {
-      if (entry.isIntersecting) {
+      if (entry.isIntersecting && hasMore) {
         observer.unobserve(entry.target);
         onIntersect(entry, observer);
       }
     },
-    [onIntersect]
+    [onIntersect, hasMore]
   );
 
   /*컴포넌트 렌더가 완료됨에 따라 observer가 생성되어야 하므로 useEffect를 활용해야 한다. 
@@ -18,13 +18,13 @@ function useInfiniteScroll(onIntersect) {
 
   useEffect(() => {
     let observer;
-    if (ref.current) {
+    if (ref.current && hasMore) {
       // 관찰 대상이 존재하는 체크한다.
       observer = new IntersectionObserver(handleIntersect, { threshold: 0.6 }); // 관찰 대상이 존재한면 관찰자를 생성한다.
       observer.observe(ref.current); // 관찰자에게 타켓을 지정해준다.
     }
     return () => observer && observer.disconnect();
-  }, [ref, handleIntersect]);
+  }, [ref, handleIntersect, hasMore]); // hasMore가 false일 때 observer 해제
 
   return ref;
 }


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
closes #148 
<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용
- useInfiniteScroll 훅 작성
- 최신 업데이트 플리 처음에 5개 호출
- 이후부터 5개씩 추가 호출
- 데이터가 더이상 없을 경우 무한 호출 방지

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

https://github.com/user-attachments/assets/084ecc2b-50b1-4149-9065-01f1c772c2fd


수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

홈 페이지의 '최근 업데이트' 재생 목록에 무한 스크롤을 도입하여 사용자가 스크롤할 때 더 많은 항목을 로드할 수 있도록 합니다. 스크롤 동작을 관리하고 모든 항목이 가져와질 때 불필요한 데이터 로드를 방지하기 위해 커스텀 훅인 useInfiniteScroll을 구현합니다. 데이터 가져오기 작업 중 로딩 스피너를 통해 사용자 경험을 향상시킵니다.

새로운 기능:
- 홈 페이지의 '최근 업데이트' 재생 목록에 무한 스크롤 기능을 구현하여 처음에는 5개의 항목을 로드하고 사용자가 스크롤할 때 더 많은 항목을 로드합니다.

개선 사항:
- 무한 스크롤 기능에서 더 많은 항목이 가져와질 때 이를 나타내기 위해 로딩 스피너를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce infinite scroll to the 'Recent Updates' playlist on the home page, allowing users to load more items as they scroll. Implement a custom hook, useInfiniteScroll, to manage the scroll behavior and prevent unnecessary data loading when all items are fetched. Enhance user experience with a loading spinner during data fetch operations.

New Features:
- Implement infinite scroll functionality for the 'Recent Updates' playlist on the home page, initially loading 5 items and loading more as the user scrolls.

Enhancements:
- Add a loading spinner to indicate when more items are being fetched in the infinite scroll feature.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->