### PR TITLE
[Fix] PlaylistPage와 VideoModal 컴포넌트의 버그 픽스

### DIFF
--- a/src/components/page/playlistdetail/VideoBoxDetail.tsx
+++ b/src/components/page/playlistdetail/VideoBoxDetail.tsx
@@ -63,6 +63,7 @@ const containerStyle = css`
   position: relative;
   display: flex;
   align-items: flex-start;
+  width: 100%;
 `;
 
 const detailsStyle = css`

--- a/src/components/page/videoModal/VideoModal.tsx
+++ b/src/components/page/videoModal/VideoModal.tsx
@@ -240,7 +240,7 @@ const VideoModal = ({ isOpen, onClose, videoId, playlist, userId }: VideoModalPr
                   <div
                     {...provided.droppableProps}
                     ref={provided.innerRef}
-                    css={playlistContainerStyle}
+                    css={[playlistContainerStyle, userId === playlist.userId ? '' : extraStyle]}
                   >
                     {currentPlaylist.videos.map((video, index) => (
                       <Draggable
@@ -256,9 +256,11 @@ const VideoModal = ({ isOpen, onClose, videoId, playlist, userId }: VideoModalPr
                             css={videoBoxWrapperStyle(snapshot.isDragging)}
                           >
                             <div css={videoBoxInnerStyle}>
-                              <div {...provided.dragHandleProps} css={dragHandleStyle}>
-                                <MdDragHandle />
-                              </div>
+                              {userId === playlist.userId && ( // 여기서 userId는 로그인한 사용자
+                                <div {...provided.dragHandleProps} css={[dragHandleStyle]}>
+                                  <MdDragHandle />
+                                </div>
+                              )}
                               <VideoBoxDetail
                                 video={video}
                                 type={currentPlaylist.userId === userId ? 'host' : 'visitor'}
@@ -466,6 +468,9 @@ const dragHandleStyle = css`
     width: 20px;
     height: 20px;
   }
+`;
+const extraStyle = css`
+  padding-left: 1rem;
 `;
 const playlistContainerStyle = css`
   flex: 1;

--- a/src/components/page/videoModal/VideoModal.tsx
+++ b/src/components/page/videoModal/VideoModal.tsx
@@ -529,8 +529,30 @@ const iconStyle = (isVisible: boolean) => css`
 `;
 const controlsContainerStyle = (isMinimized: boolean) => css`
   flex: 1;
-  transition: all 300ms ease-in-out;
-  height: ${isMinimized ? '0' : 'auto'};
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  padding-bottom: 2rem;
+  // max-height: calc(70vh - 300px); // 예시 값, 실제 비디오 플레이어와 헤더의 높이에 따라 조정 필요
+  // min-height: 1000px; // 최소 높이 설정
+  // background-color: gold;
+
+  ${isMinimized
+    ? css`
+        display: none;
+      `
+    : css`
+        &::-webkit-scrollbar {
+          width: 6px;
+        }
+        &::-webkit-scrollbar-thumb {
+          background-color: ${theme.colors.darkGray};
+          border-radius: 3px;
+        }
+        &::-webkit-scrollbar-track {
+          background-color: ${theme.colors.black};
+        }
+      `}
 `;
 const iframeStyle = (loaded: boolean) => css`
   position: absolute;

--- a/src/components/page/videoModal/VideoModal.tsx
+++ b/src/components/page/videoModal/VideoModal.tsx
@@ -297,10 +297,10 @@ const modalOverlayStyle = (isMinimized: boolean, isClosing: boolean) => css`
   left: 0;
   right: 0;
   bottom: ${isMinimized ? '80px' : '0'};
-
   width: 498px;
   height: ${isMinimized ? '60px' : '100vh'};
   background-color: ${isMinimized ? 'transparent' : theme.colors.black};
+
   display: flex;
   justify-content: center;
   align-items: ${isMinimized ? 'flex-end' : 'flex-start'};
@@ -483,12 +483,14 @@ const minimizedControlsStyle = css`
 `;
 
 const videoInfoStyle = css`
-  flex: 1;
-  margin-right: 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
 `;
 
 const videoTitleStyle = css`
-  font-size: ${theme.fontSizes.small};
+  font-size: ${theme.fontSizes.normal};
   color: ${theme.colors.white};
   width: 280px;
   white-space: nowrap;
@@ -498,7 +500,7 @@ const videoTitleStyle = css`
 `;
 
 const uploaderNameStyle = css`
-  font-size: ${theme.fontSizes.xsmall};
+  font-size: ${theme.fontSizes.small};
   color: ${theme.colors.disabled};
 `;
 
@@ -530,16 +532,16 @@ const iconStyle = (isVisible: boolean) => css`
 const controlsContainerStyle = (isMinimized: boolean) => css`
   flex: 1;
   display: flex;
+
   flex-direction: column;
   overflow-y: auto;
-  padding-bottom: 2rem;
   // max-height: calc(70vh - 300px); // 예시 값, 실제 비디오 플레이어와 헤더의 높이에 따라 조정 필요
   // min-height: 1000px; // 최소 높이 설정
-  // background-color: gold;
 
   ${isMinimized
     ? css`
-        display: none;
+        display: block;
+        padding-bottom: 0;
       `
     : css`
         &::-webkit-scrollbar {

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -88,7 +88,7 @@ const containerStyle = css`
 const addButtonContainerStyle = css`
   position: fixed;
   left: 50%;
-  bottom: 96px;
+  bottom: 9rem;
   width: 100vw;
   max-width: 500px;
   height: 1px;

--- a/src/pages/PlaylistPage.tsx
+++ b/src/pages/PlaylistPage.tsx
@@ -279,7 +279,7 @@ const PlaylistPage: React.FC = () => {
               <div
                 {...provided.droppableProps}
                 ref={provided.innerRef}
-                css={playlistContainerStyle}
+                css={[playlistContainerStyle, userId === playlist.userId ? '' : extraStyle]}
               >
                 {playlist.videos.map((video, index) => (
                   <Draggable key={video.videoId} draggableId={video.videoId || ''} index={index}>
@@ -292,9 +292,11 @@ const PlaylistPage: React.FC = () => {
                         css={videoBoxWrapperStyle(snapshot.isDragging)}
                       >
                         <div css={draggableListStyle}>
-                          <div {...provided.dragHandleProps} css={dragHandleStyle}>
-                            <MdDragHandle />
-                          </div>
+                          {userId === playlist.userId && ( // 여기서 userId는 로그인한 사용자
+                            <div {...provided.dragHandleProps} css={dragHandleStyle}>
+                              <MdDragHandle />
+                            </div>
+                          )}
                           <VideoBoxDetail
                             video={video}
                             type={playlist.userId === userId ? 'host' : 'visitor'}
@@ -440,7 +442,9 @@ const dragHandleStyle = css`
     height: 20px;
   }
 `;
-
+const extraStyle = css`
+  padding-left: 1rem;
+`;
 const playlistContainerStyle = css`
   flex: 1;
   padding: 0 0.5rem;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
closes #166 
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 비디오모달에서 비디오목록에 스크롤이 생기지 않는 문제 수정
- 미니플레이어 떠 있을때 가정하여 링크추가버튼 위치 수정
- 로그인한 사용자의 플레이리스트 목록만 순서변경 가능하도록 수정
    
    - 로그인한 사용자 아이디로 해당 플레이리스트 데이터의 userId와 비교
    - 같은 사용자 아이디일 경우에만 순서변경 가능하도록 수정
    - 로그인한 유저의 아이디와 해당 플레이리스트의 userId가 다를 경우 순서변경 버튼 안보이도록 수정
        - 드래그 핸들이 사라졌으므로 목록의 좌측 여백을 1rem으로 설정

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

VideoModal 및 PlaylistPage 구성 요소의 버그를 수정하고, 스크롤바 문제 및 버튼 위치를 포함합니다. 로그인한 사용자에게만 재생목록 재정렬을 허용하고 텍스트 스타일을 개선하여 사용자 경험을 향상시킵니다.

버그 수정:
- VideoModal 구성 요소의 비디오 목록에 스크롤바가 없던 문제를 수정합니다.
- 미니 플레이어가 활성화될 때 링크 추가 버튼의 위치를 조정합니다.

개선 사항:
- 사용자 ID를 비교하여 로그인한 사용자에게만 재생목록 재정렬을 제한하고, 소유자가 아닌 사용자에게는 드래그 핸들을 숨깁니다.
- 비디오 제목 및 업로더 이름의 스타일을 업데이트하여 가독성을 향상시킵니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix bugs in the VideoModal and PlaylistPage components, including scrollbar issues and button positioning. Enhance user experience by allowing playlist reordering only for logged-in users and improving text styling.

Bug Fixes:
- Fix the issue where the video list in the VideoModal component did not have a scrollbar.
- Adjust the position of the link addition button when the mini player is active.

Enhancements:
- Restrict playlist reordering to only logged-in users by comparing user IDs, and hide the drag handle for non-owners.
- Update the styling of video titles and uploader names for better readability.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->