### PR TITLE
[Fix] 플레이리스트의 업로더를 클릭하면 해당 업로더의 마이페이지가 아닌 내 마이페이지로 이동하는 버그 수정

### DIFF
--- a/src/hooks/queries/useUserQueries.ts
+++ b/src/hooks/queries/useUserQueries.ts
@@ -3,20 +3,17 @@ import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import { getUserData } from '@/api/endpoints/user';
 import { QUERY_KEYS } from '@/constants/queryKey';
 import { UserModel } from '@/types/user';
-import { getUserIdBySession } from '@/utils/user';
+
 // 기본 옵션
 const defaultOptions = {
   staleTime: 5 * 60 * 1000, // 기본 5분
 };
 
-// 세션의 userId를 통해 해당 사용자 정보 가져오기
-export const useUserData = (): UseQueryResult<UserModel, Error> => {
-  // 세션에서 userId 가져오기
-  const uid = getUserIdBySession();
-  return useQuery({
+// userId를 파라미터로 받도록 변경
+export const useUserData = (uid: string): UseQueryResult<UserModel, Error> =>
+  useQuery({
     queryKey: [QUERY_KEYS.USER_USERID_KEY, uid],
     queryFn: () => getUserData(uid),
     ...defaultOptions,
     enabled: !!uid, // userId가 존재할 때만 쿼리 실행
   });
-};

--- a/src/pages/Mypage.tsx
+++ b/src/pages/Mypage.tsx
@@ -1,11 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import { css } from '@emotion/react';
 import { RiAddLargeLine } from 'react-icons/ri';
 import { useParams, useNavigate } from 'react-router-dom';
 
-import { getUserPlaylists } from '@/api/endpoints/playlist';
-import { getUserData } from '@/api/endpoints/user';
 import IconButton from '@/components/common/buttons/IconButton';
 import Spinner from '@/components/common/Spinner';
 import Toast from '@/components/common/Toast';
@@ -14,18 +12,21 @@ import MyProfile from '@/components/page/mypage/MyProfile';
 import { PATH } from '@/constants/path';
 import { useUserPlaylists } from '@/hooks/queries/usePlaylistQueries';
 import { useUserData } from '@/hooks/queries/useUserQueries';
-import { PlaylistModel } from '@/types/playlist';
-import { UserModel } from '@/types/user';
 import { getUserIdBySession } from '@/utils/user';
 
 const MyPage = () => {
   const navigate = useNavigate();
+  const { userId } = useParams<{ userId: string }>();
+
+  // 유저 데이터 가져오기
   const {
     data: userData,
     isLoading: isUserLoading,
     error: userError,
     refetch: refetchUserData,
-  } = useUserData();
+  } = useUserData(userId || getUserIdBySession()); // userId가 없으면 세션의 userId로 대체
+
+  // 유저의 플레이리스트 가져오기
   const {
     data: playlists,
     isLoading: isPlaylistsLoading,


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- useUserData함수 내의 세션으로부터 아이디를 가져오는 로직을 분리하여, 파라미터값을 외부로 부터 받아오도록 변경
- 마이페이지에서(사용하는 페이지에서) 세션으로부터 아이디를 가져옴
- 마이페이지에 외부로 받아오는 userId를 useParams로 받아오고,
- useUserData함수의 파라미터로 넣어줌. 그런데 만약 값이 없다면 세션의 userId로 대체함
## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

`useUserData` 함수가 `userId` 매개변수를 수락하도록 수정하여, 플레이리스트 업로더를 클릭할 때 업로더의 MyPage로 올바르게 리디렉션되도록 합니다. `userId`가 제공되지 않으면 세션의 `userId`를 기본값으로 사용합니다.

버그 수정:
- `userId`를 매개변수로 수락하도록 로직을 수정하여, 플레이리스트 업로더를 클릭할 때 사용자의 MyPage가 아닌 업로더의 MyPage로 리디렉션되는 버그를 수정합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Modify the useUserData function to accept a userId parameter, allowing for correct redirection to the uploader's MyPage when clicking on a playlist uploader. If no userId is provided, default to using the session's userId.

Bug Fixes:
- Fix the bug where clicking on a playlist uploader redirects to the user's own MyPage instead of the uploader's MyPage by modifying the logic to accept userId as a parameter.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->