### PR TITLE
[Fix] 검색페이지 플레이리스트 5개만 나오는 버그 수정

### DIFF
--- a/src/api/endpoints/playlistFetch.ts
+++ b/src/api/endpoints/playlistFetch.ts
@@ -20,10 +20,10 @@ import { UserModel } from '@/types/user';
 const db = getFirestore(app);
 
 // 전체 플레이리스트 가져오기
-export const getAllPlaylists = async (limitCount: number = 20): Promise<PlaylistModel[]> => {
+export const getAllPlaylists = async (): Promise<PlaylistModel[]> => {
   try {
     const playlistsCol = collection(db, 'playlists');
-    const playlistQuery = query(playlistsCol, orderBy('createdAt', 'desc'), limit(limitCount));
+    const playlistQuery = query(playlistsCol, orderBy('createdAt', 'desc'));
     const playlistSnapshot = await getDocs(playlistQuery);
 
     return playlistSnapshot.docs.map(

--- a/src/components/common/PlaylistItem.tsx
+++ b/src/components/common/PlaylistItem.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { css } from '@emotion/react';
 import { GoBookmark, GoBookmarkFill } from 'react-icons/go';
 
-import { IS_PUBLIC } from '@/constants/\bnormal';
+import { IS_PUBLIC } from '@/constants/normal';
 import theme from '@/styles/theme';
 
 interface PlaylistItemProps {

--- a/src/components/common/ToggleSwitch.tsx
+++ b/src/components/common/ToggleSwitch.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { css, SerializedStyles } from '@emotion/react';
 import * as Switch from '@radix-ui/react-switch';
 
-import { IS_PUBLIC } from '@/constants/\bnormal';
+import { IS_PUBLIC } from '@/constants/normal';
 import theme from '@/styles/theme';
 
 interface ToggleSwitchProps {

--- a/src/hooks/useFilteredPlaylists.ts
+++ b/src/hooks/useFilteredPlaylists.ts
@@ -18,7 +18,7 @@ export const useFilteredPlaylists = () => {
     setDisplayedPlaylists(playlists);
     setSelectedCategory(ALL_PLAYLISTS);
   }, [playlists]);
-
+  console.log(playlists);
   // 카테고리 필터링
   const handleButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     const category = e.currentTarget.textContent;


### PR DESCRIPTION
- 파이어베이스 `limit` 기본값이 5로 설정되어있었음

# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 검색페이지 플레이리스트 5개만 나오는 버그 수정
- 파이어베이스 `limit` 기본값으로 생긴 오류