### PR TITLE
[Fix] 메인페이지 내 관심사와 비슷한 플레이리스트에서 나의 플레이리스트도 나오는 버그 수정

### DIFF
--- a/src/hooks/useSortedPlaylists.ts
+++ b/src/hooks/useSortedPlaylists.ts
@@ -31,8 +31,8 @@ export const usePopularPlaylists = () => {
   const errorForAllForkedPlaylist = forkedPlaylistsQueries.find((query) => query.error);
   const allForkedPlaylists = forkedPlaylistsQueries
     .flatMap((query) => query.data || [])
+    .filter((playlist) => playlist.userId !== userId)
     .filter((playlist) => playlist.isPublic === true);
-
   useEffect(() => {
     const fetchPlaylists = async () => {
       const playlistsByPopularity = sortPlaylistsByPopularity(allPlaylists as PlaylistModel[]);

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -17,15 +17,15 @@ export const formatTimeWithUpdated = (dateString: string): string => {
 
   if (diffInHours < 1) {
     return `방금`;
-  } else if (diffInHours > 1 && diffInHours < 24) {
+  } else if (diffInHours >= 1 && diffInHours < 24) {
     return `${diffInHours}시간 전`;
-  } else if (diffInDays < 7) {
+  } else if (diffInDays >= 1 && diffInDays < 7) {
     return `${diffInDays}일 전`;
-  } else if (diffInWeeks > 0 && diffInMonths < 1) {
+  } else if (diffInWeeks >= 1 && diffInMonths < 1) {
     return `${diffInWeeks}주 전`;
-  } else if (diffInMonths > 0 && diffInYears < 1) {
+  } else if (diffInMonths >= 1 && diffInYears < 1) {
     return `${diffInMonths}개월 전`;
-  } else if (diffInYears > 0) {
+  } else if (diffInYears >= 1) {
     return `${diffInYears}년 전`;
   } else {
     return `잘못된 날짜 형식입니다.`;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

1. 메인페이지 내 관심사와 비슷한 플레이리스트에서 나의 플레이리스트도 나오는 버그 수정
  - 필터링된 플레이리스트에서 현재 사용자의 `userId`와 동일한 플레이리스트는 제외
  
2. 메인페이지 플레이리스트의 업데이트 일자가 0일 전으로 나오는 버그 수정
- 현재 1시간보다 클 경우에만 시간 단위가 적용이었기에 1시간 미만의 경우 0일 전으로 나왔음
- 1 이상으로 단위를 수정