### PR TITLE
[Refactor] 댓글 필터링 기능 리팩토링 및 데이터 상수화 작업

### DIFF
--- a/src/components/page/comment/CommentBox.tsx
+++ b/src/components/page/comment/CommentBox.tsx
@@ -7,6 +7,7 @@ import { deleteComment } from '@/api/endpoints/comment';
 import { getPlaylistById } from '@/api/endpoints/playlistFetch';
 import defaultImg from '@/assets/images/default-avatar-man.svg';
 import Toast from '@/components/common/Toast';
+import { COMMENTS } from '@/constants/comment';
 import { useCommentsList } from '@/hooks/queries/useCommentsQueries';
 import { useToastStore } from '@/store/useToastStore';
 import theme from '@/styles/theme';
@@ -47,7 +48,7 @@ const CommentBox: React.FC<CommentBoxProps> = ({
 
     try {
       await deleteComment(commentData.playlistId, commentData.commentId);
-      showToast('댓글이 삭제되었습니다');
+      showToast(COMMENTS.toast.delete);
 
       const updatedPlaylistData = await getPlaylistById(commentData.playlistId);
 
@@ -74,7 +75,7 @@ const CommentBox: React.FC<CommentBoxProps> = ({
     <>
       <div css={CommentListStyle}>
         <div>
-          <img src={comments.profileImg || defaultImg} alt='미니 썸네일' />
+          <img src={comments.profileImg || defaultImg} alt='profile' />
           <div>
             <h1>{comments.userName}</h1>
             <h2>{formatTimeWithUpdated(comments.createdAt)}</h2>

--- a/src/constants/comment.ts
+++ b/src/constants/comment.ts
@@ -1,0 +1,10 @@
+export const COMMENT_FILTER_OPTIONS = [
+  { value: 'latest', label: '최신순' },
+  { value: 'oldest', label: '오래된순' },
+];
+
+export const COMMENTS = {
+  toast: {
+    delete: '해당 댓글이 삭제되었습니다.',
+  },
+};

--- a/src/constants/title.ts
+++ b/src/constants/title.ts
@@ -1,0 +1,1 @@
+export const PLAYLIST_TITLE = '내가 구독중인 플레이리스트';

--- a/src/constants/title.ts
+++ b/src/constants/title.ts
@@ -1,1 +1,3 @@
-export const PLAYLIST_TITLE = '내가 구독중인 플레이리스트';
+export const TITLE = {
+  subscribed_page: '내가 구독중인 플레이리스트',
+};

--- a/src/pages/CommentList.tsx
+++ b/src/pages/CommentList.tsx
@@ -9,6 +9,7 @@ import IconTextButton from '@/components/common/buttons/IconTextButton';
 import SelectBox from '@/components/common/SelectBox';
 import Toast from '@/components/common/Toast';
 import CommentBox from '@/components/page/comment/CommentBox';
+import { COMMENT_FILTER_OPTIONS } from '@/constants/comment';
 import { PATH } from '@/constants/path';
 import { useCommentsList } from '@/hooks/queries/useCommentsQueries';
 import Header from '@/layouts/layout/Header';
@@ -22,16 +23,12 @@ const CommentList = () => {
   const [comments, setComments] = useState<Comment[]>([]); // 직접 comments 조작
   const [playlistData, setPlaylistData] = useState<PlaylistModel | undefined>();
   const [selectedFilter, setSelectedFilter] = useState<string>('latest');
-  const [originalComments, setOriginalComments] = useState<Comment[]>([]); // sort 전 마지막 comments를 저장하는 용도
   const showToast = useToastStore((state) => state.showToast);
   const navigate = useNavigate();
   const location = useLocation();
-
   const { toastMessage, refetchComments } = location.state || {};
-  const filterOptions = [
-    { value: 'latest', label: '최신순' },
-    { value: 'oldest', label: '오래된순' },
-  ];
+
+  const filterOptions = COMMENT_FILTER_OPTIONS;
 
   const goToCommentForm = () => {
     navigate(`${PATH.COMMENT_ADD.replace(':playlistId', playlistId ?? '')}`, {
@@ -46,24 +43,7 @@ const CommentList = () => {
 
   const handleFilterChange = (value: string) => {
     setSelectedFilter(value);
-    switch (value) {
-      case 'latest':
-        setComments(
-          [...originalComments].sort(
-            (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-          )
-        );
-        break;
-      case 'oldest':
-        setComments(
-          [...comments].sort(
-            (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-          )
-        );
-        break;
-      default:
-        break;
-    }
+    setComments([...comments].reverse());
   }; // 댓글 필터링
 
   const { data: commentsData, error, refetch } = useCommentsList(playlistId);
@@ -71,7 +51,6 @@ const CommentList = () => {
   useEffect(() => {
     if (commentsData) {
       setComments(commentsData);
-      setOriginalComments(commentsData);
     }
 
     async function fetchPlaylistData() {
@@ -116,7 +95,7 @@ const CommentList = () => {
       <Toast />
       <div css={CommentTabStyle}>
         <div>
-          <img src={playlistData?.thumbnailUrl} alt='미니 썸네일' />
+          <img src={playlistData?.thumbnailUrl} alt='playlist' />
           <div>
             <p>{playlistData?.title}</p>
             <p>{playlistData?.userName}</p>
@@ -133,7 +112,6 @@ const CommentList = () => {
       </div>
       <div css={CommentListDivStyle}>
         <div css={CommentListTopStyle}>
-          {/* 댓글 수 / 필터 div */}
           <p>댓글 수 {playlistData?.commentCount}</p>
           <SelectBox items={filterOptions} value={selectedFilter} onChange={handleFilterChange} />
         </div>

--- a/src/pages/Subscriptions.tsx
+++ b/src/pages/Subscriptions.tsx
@@ -8,14 +8,13 @@ import IconButton from '@/components/common/buttons/IconButton';
 import Toast from '@/components/common/Toast';
 import PlaylistBox from '@/components/page/playlist/PlaylistBox';
 import { PLAYLIST } from '@/constants/playlist';
+import { PLAYLIST_TITLE } from '@/constants/title';
 import theme from '@/styles/theme';
 import { PlaylistModel } from '@/types/playlist';
 import { getUserIdBySession } from '@/utils/user';
 
 const Subscriptions: React.FC = () => {
   const [forkedPlaylists, setForkedPlaylist] = useState<PlaylistModel[]>([]);
-  // const { isToggled, toggle } = useToggleStore();
-  // const { showToast } = useToastStore();
 
   const useId = getUserIdBySession();
 
@@ -31,7 +30,7 @@ const Subscriptions: React.FC = () => {
   return (
     <div css={containerStyle}>
       <header css={header}>
-        <p>내가 구독중인 플레이리스트</p>
+        <p>{PLAYLIST_TITLE}</p>
       </header>
 
       {forkedPlaylists && forkedPlaylists.length > 0 ? (

--- a/src/pages/Subscriptions.tsx
+++ b/src/pages/Subscriptions.tsx
@@ -8,7 +8,7 @@ import IconButton from '@/components/common/buttons/IconButton';
 import Toast from '@/components/common/Toast';
 import PlaylistBox from '@/components/page/playlist/PlaylistBox';
 import { PLAYLIST } from '@/constants/playlist';
-import { PLAYLIST_TITLE } from '@/constants/title';
+import { TITLE } from '@/constants/title';
 import theme from '@/styles/theme';
 import { PlaylistModel } from '@/types/playlist';
 import { getUserIdBySession } from '@/utils/user';
@@ -30,7 +30,7 @@ const Subscriptions: React.FC = () => {
   return (
     <div css={containerStyle}>
       <header css={header}>
-        <p>{PLAYLIST_TITLE}</p>
+        <p>{TITLE.subscribed_page}</p>
       </header>
 
       {forkedPlaylists && forkedPlaylists.length > 0 ? (


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 댓글 필터링 로직 sort -> reverse로 변경 (댓글 많아질 때 처리속도 상승)
- constants폴더에 comment.ts, title.ts 생성 및 string값 상수화
- 불필요한 주석 삭제


## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

주석 필터링 기능을 리팩토링하여 성능을 향상시키기 위해 sort 대신 reverse를 사용합니다. 주석 필터와 토스트 메시지의 문자열 값을 중앙 집중화하여 유지보수성을 향상시키기 위해 constants 폴더를 도입합니다. 불필요한 주석을 제거하여 코드를 정리합니다.

향상 사항:
- 대규모 주석 집합에서 성능을 개선하기 위해 sort 대신 reverse를 사용하여 주석 필터링 로직을 리팩토링합니다.
- 새로운 constants 폴더에 주석 필터 옵션과 토스트 메시지에 대한 상수를 생성하여 문자열 값을 중앙 집중화합니다.

작업:
- 코드베이스에서 불필요한 주석을 제거하여 가독성을 향상시킵니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the comment filtering functionality to enhance performance by using reverse instead of sort. Introduce a constants folder to centralize string values for comment filters and toast messages, improving maintainability. Clean up the code by removing unnecessary comments.

Enhancements:
- Refactor comment filtering logic to use reverse instead of sort for improved performance with large comment sets.
- Centralize string values by creating constants for comment filter options and toast messages in a new constants folder.

Chores:
- Remove unnecessary comments from the codebase to improve readability.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->