### PR TITLE
[Refactor] 구글 로그인시 userPlaylists 초기화 문제 해결

### DIFF
--- a/src/components/page/signin/GoogleLogin.tsx
+++ b/src/components/page/signin/GoogleLogin.tsx
@@ -37,15 +37,15 @@ const GoogleLoginButton: React.FC = () => {
         });
       }
 
-      await setDoc(
-        userPlaylistsDocRef,
-        {
+      const userPlaylistsDoc = await getDoc(userPlaylistsDocRef);
+
+      if (!userPlaylistsDoc.exists()) {
+        await setDoc(userPlaylistsDocRef, {
           created: [],
           forked: [],
           liked: [],
-        },
-        { merge: true }
-      );
+        });
+      }
 
       sessionStorage.setItem(
         'userSession',

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -31,7 +31,6 @@ const SignIn = () => {
     if (isFormValid) {
       try {
         const userCredential = await signInWithEmailAndPassword(auth, username, password);
-        console.log('로그인 성공:', userCredential.user.email);
         setErrorMessage('');
         sessionStorage.setItem(
           'userSession',


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
close #220 
<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

GoogleLogin에서 로그아웃시 구독및 좋아요 생성 데이터 날라가는 부분 수정. 

 await setDoc(
        userPlaylistsDocRef,
        {
          created: [],
          forked: [],
          liked: [],
        },
        { merge: true }
      );
기존 코드는 구글 로그인시 이 함수가 동작하여  created,forked,liked 배열이 빈 배열로 덮어씌어 초기화가 되었는데  조건문으로 변경해서 유저데이터가 있으면 실행되지 않고 없는 새로운 유저일때만 동작하도록 수정

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

Google 로그인 시 사용자 재생 목록이 초기화되는 문제를 수정하여, 초기화가 새로운 사용자에게만 발생하도록 하고, SignIn 컴포넌트에서 불필요한 콘솔 로그 문을 제거합니다.

버그 수정:
- Google 로그인 시 사용자 재생 목록이 빈 배열로 잘못 초기화되는 문제를 수정하여, 새로운 사용자에게만 재생 목록을 초기화하는 조건을 추가합니다.

개선 사항:
- 코드를 정리하기 위해 SignIn 컴포넌트에서 불필요한 콘솔 로그 문을 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the issue where user playlists are reset during Google login by ensuring initialization only occurs for new users, and remove an unnecessary console log statement from the SignIn component.

Bug Fixes:
- Fix issue where user playlists were incorrectly reset to empty arrays during Google login by adding a condition to only initialize playlists for new users.

Enhancements:
- Remove unnecessary console log statement from the SignIn component to clean up the code.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->