### PR TITLE
[refactor] 타입에러, lint에러, 사용되지않은 선언 제거

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -57,8 +57,8 @@ module.exports = {
     'prefer-const': 'error',
     // var 대신 let과 const 사용 강제
     'no-var': 'error',
-    // 사용하지 않는 변수 경고 (언더스코어로 시작하는 변수 제외)
-    'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+    // 'no-unused-vars' 규칙 제거
+    'no-unused-vars': 'off',
     // === 와 !== 사용 강제(타입 강제 변환으로 인한 예기치 않은 동작을 방지)
     eqeqeq: 'error',
     // 객체 구조 분해 할당 권장(코드를 더 간결하고 읽기 쉽게 만들며, 필요한 속성만 명시적으로 사용할 수 있게 할 수 있음)
@@ -91,11 +91,12 @@ module.exports = {
     ],
     // JSX에서 중복된 props 방지(실수로 같은 prop을 여러 번 사용하는 것을 방지하여 버그를 예방)
     'react/jsx-no-duplicate-props': ['error', { ignoreCase: true }],
+    // TypeScript 전용으로 설정
     '@typescript-eslint/no-unused-vars': [
-      'warn',
+      'error', // 'warn'을 'error'로 변경
       {
-        varsIgnorePattern: '^_',
-        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_', // '_'로 시작하는 변수는 무시
+        argsIgnorePattern: '^_', // '_'로 시작하는 함수 매개변수는 무시
       },
     ],
     // 빈 인터페이스를 허용

--- a/src/components/common/modals/Dialog.tsx
+++ b/src/components/common/modals/Dialog.tsx
@@ -22,8 +22,8 @@ interface DialogProps {
   onConfirm?: () => void;
   onCancel?: () => void;
   setVideoData?: Dispatch<SetStateAction<Partial<Video> | undefined>>;
-  youtubeUrl: string;
-  setYoutubeUrl: Dispatch<SetStateAction<string>>;
+  youtubeUrl?: string;
+  setYoutubeUrl?: Dispatch<SetStateAction<string>>;
 }
 
 const CustomDialog: React.FC<DialogProps> = ({
@@ -40,19 +40,20 @@ const CustomDialog: React.FC<DialogProps> = ({
   const [isConfirmDisabled, setIsConfirmDisabled] = useState(true);
 
   // videoData를 상위 컴포넌트(Playlist)로 넘기기 위한 커스텀훅 사용
-  const { data: videoData } = useVideoData(youtubeUrl as string);
+  const { data: videoData } = useVideoData(youtubeUrl || '');
 
   useEffect(() => {
     setIsConfirmDisabled(type !== 'alertConfirm' && !videoData);
 
-    if (setVideoData && videoData)
+    if (setVideoData && videoData && youtubeUrl) {
       setVideoData({
         ...videoData,
         videoId: getVideoId(youtubeUrl),
         videoUrl: youtubeUrl,
         duration: formatDurationISOToTime(videoData.duration),
       });
-  }, [videoData]);
+    }
+  }, [videoData, youtubeUrl, setVideoData, type]);
 
   const getModalContent = (type: DialogProps['type']) => {
     switch (type) {
@@ -105,7 +106,7 @@ const CustomDialog: React.FC<DialogProps> = ({
                 css={inputStyle}
                 placeholder='영상 링크를 입력하세요'
                 value={youtubeUrl}
-                onChange={(e) => setYoutubeUrl(e.target.value)}
+                onChange={(e) => setYoutubeUrl && setYoutubeUrl(e.target.value)}
               />
             </>
           ),

--- a/src/components/page/playlist/PlaylistBox.tsx
+++ b/src/components/page/playlist/PlaylistBox.tsx
@@ -55,7 +55,7 @@ const PlaylistBox: React.FC<PlaylistBoxProps> = ({
     };
 
     fetchUserData();
-  }, []);
+  }, [playlistUserId]);
 
   useEffect(() => {
     const fetchInitialForkedState = async () => {

--- a/src/components/page/search/CategoryButtons.tsx
+++ b/src/components/page/search/CategoryButtons.tsx
@@ -1,5 +1,3 @@
-import { useRef, useState } from 'react';
-
 import { css } from '@emotion/react';
 
 import { PLAYLIST } from '@/constants/playlist';

--- a/src/hooks/useDragToScroll.ts
+++ b/src/hooks/useDragToScroll.ts
@@ -6,7 +6,7 @@ export const useDragToScroll = () => {
   const [scrollLeft, setScrollLeft] = useState(0);
   const [dragDistance, setDragDistance] = useState(0);
 
-  const onMouseDown = (e: React.MouseEvent) => {
+  const onMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     setIsDragging(true);
     setDragDistance(0);
     setStartX(e.pageX - e.currentTarget.offsetLeft);
@@ -14,7 +14,7 @@ export const useDragToScroll = () => {
     document.body.style.userSelect = 'none';
   };
 
-  const onMouseMove = (e: React.MouseEvent) => {
+  const onMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
     if (!isDragging) return;
     const x = e.pageX - e.currentTarget.offsetLeft;
     const walk = (x - startX) * 1;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
closes #237 
<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- lint no-unused-vars': 'error' 설정변경
- Dialog 필수 props 변경
- categoryButtons 사용되지 않는 값 제거

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

코드 리팩토링을 통해 타입 안전성과 린트 규칙을 개선합니다. Dialog 컴포넌트를 업데이트하여 특정 props를 선택적으로 만들고, useVideoData 훅을 이에 맞게 조정합니다. useDragToScroll 훅을 더 구체적인 이벤트 핸들러 타입으로 향상시킵니다. ESLint 설정을 수정하여 'no-unused-vars'를 비활성화하고 '@typescript-eslint/no-unused-vars'를 오류로 강제합니다.

개선 사항:
- Dialog 컴포넌트에서 'youtubeUrl'과 'setYoutubeUrl' props를 선택적으로 만듭니다.
- Dialog 컴포넌트에서 선택적인 'youtubeUrl'을 처리하기 위해 'useVideoData' 훅 사용을 업데이트합니다.
- 'useDragToScroll' 훅의 이벤트 핸들러에 'HTMLDivElement'를 지정하여 타입 구체성을 추가합니다.

빌드:
- ESLint 설정을 변경하여 'no-unused-vars' 규칙을 비활성화하고 '@typescript-eslint/no-unused-vars'를 'error'로 설정합니다.

잡일:
- 'categoryButtons'에서 사용되지 않는 값을 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor code to improve type safety and linting rules. Update the Dialog component to make certain props optional and adjust the useVideoData hook accordingly. Enhance the useDragToScroll hook with more specific event handler types. Modify ESLint configuration to disable 'no-unused-vars' and enforce '@typescript-eslint/no-unused-vars' as an error.

Enhancements:
- Make 'youtubeUrl' and 'setYoutubeUrl' props optional in the Dialog component.
- Update the 'useVideoData' hook usage to handle optional 'youtubeUrl' in the Dialog component.
- Add type specificity to event handlers in the 'useDragToScroll' hook by specifying 'HTMLDivElement'.

Build:
- Change ESLint configuration to disable the 'no-unused-vars' rule and set '@typescript-eslint/no-unused-vars' to 'error'.

Chores:
- Remove unused values from 'categoryButtons'.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->