### PR TITLE
[Feat] 댓글 프로필 클릭 시 개인 페이지로 라우팅 설정

### DIFF
--- a/src/components/page/comment/CommentBox.tsx
+++ b/src/components/page/comment/CommentBox.tsx
@@ -69,7 +69,12 @@ const CommentBox: React.FC<CommentBoxProps> = ({
   };
 
   const handleProfileClick = (userId: string | undefined) => {
-    navigate('/mypage/' + userId);
+    const curUser = sessionStorage.getItem('userSession') as string;
+    const curUserId = JSON.parse(curUser).uid;
+
+    if (curUserId !== userId) {
+      navigate('/mypage/' + userId);
+    }
   };
 
   useEffect(() => {
@@ -79,7 +84,7 @@ const CommentBox: React.FC<CommentBoxProps> = ({
 
   return (
     <>
-      <div css={CommentListStyle}>
+      <div css={CommentListStyle(commentUserId === comments.userId)}>
         <div>
           <img
             src={comments.profileImg || defaultImg}
@@ -110,7 +115,7 @@ const CommentBox: React.FC<CommentBoxProps> = ({
   );
 };
 
-const CommentListStyle = css`
+const CommentListStyle = (isClickable: boolean) => css`
   margin: 10px 0;
   display: flex;
   justify-content: space-between;
@@ -120,7 +125,7 @@ const CommentListStyle = css`
     justify-content: center;
 
     img {
-      cursor: pointer;
+      cursor: ${isClickable ? 'default' : 'pointer'};
     }
     div {
       margin-left: 8px;

--- a/src/components/page/comment/CommentBox.tsx
+++ b/src/components/page/comment/CommentBox.tsx
@@ -34,6 +34,8 @@ const CommentBox: React.FC<CommentBoxProps> = ({
   const { showToast } = useToastStore();
   const { refetch } = useCommentsList(playlistId);
   const navigate = useNavigate();
+  const curUser = sessionStorage.getItem('userSession') as string;
+  const curUserId = JSON.parse(curUser).uid;
 
   const handleDelBtnClick = async (commentData: {
     playlistId: string | undefined;
@@ -69,9 +71,6 @@ const CommentBox: React.FC<CommentBoxProps> = ({
   };
 
   const handleProfileClick = (userId: string | undefined) => {
-    const curUser = sessionStorage.getItem('userSession') as string;
-    const curUserId = JSON.parse(curUser).uid;
-
     if (curUserId !== userId) {
       navigate('/mypage/' + userId);
     }

--- a/src/components/page/comment/CommentBox.tsx
+++ b/src/components/page/comment/CommentBox.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 import { css } from '@emotion/react';
 import { RiCloseFill } from 'react-icons/ri';
+import { useNavigate } from 'react-router-dom';
 
 import { deleteComment } from '@/api/endpoints/comment';
 import { getPlaylistById } from '@/api/endpoints/playlistFetch';
@@ -32,6 +33,7 @@ const CommentBox: React.FC<CommentBoxProps> = ({
   const [commentUserId, setCommentUserId] = useState<string | null>(null);
   const { showToast } = useToastStore();
   const { refetch } = useCommentsList(playlistId);
+  const navigate = useNavigate();
 
   const handleDelBtnClick = async (commentData: {
     playlistId: string | undefined;
@@ -66,6 +68,10 @@ const CommentBox: React.FC<CommentBoxProps> = ({
     }
   };
 
+  const handleProfileClick = (userId: string | undefined) => {
+    navigate('/mypage/' + userId);
+  };
+
   useEffect(() => {
     const uid = getUserIdBySession();
     setCommentUserId(uid);
@@ -75,7 +81,11 @@ const CommentBox: React.FC<CommentBoxProps> = ({
     <>
       <div css={CommentListStyle}>
         <div>
-          <img src={comments.profileImg || defaultImg} alt='profile' />
+          <img
+            src={comments.profileImg || defaultImg}
+            alt='profile'
+            onClick={() => handleProfileClick(comments.userId)}
+          />
           <div>
             <h1>{comments.userName}</h1>
             <h2>{formatTimeWithUpdated(comments.createdAt)}</h2>
@@ -109,6 +119,9 @@ const CommentListStyle = css`
     display: flex;
     justify-content: center;
 
+    img {
+      cursor: pointer;
+    }
     div {
       margin-left: 8px;
       display: flex;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

내가 아닌 다른 사용자의 댓글 프로필 이미지를 눌렀을 때, 해당 사용자의 프로필 페이지로 이동하도록 하는 기능 추가

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

![댓글라우팅](https://github.com/user-attachments/assets/d9ac3597-7530-46fb-9df1-af555afd1b9d)


## 📄 기타

![image](https://github.com/user-attachments/assets/c65eeaed-ff47-4adf-be23-54cfbb1375fa)

내 마이페이지에는 뒤로가기 버튼이 없기 때문에, 내 댓글에도 라우팅을 걸어버리면 내 마이페이지에 들어왔을 때 뒤로 갈 수 없는 현상 발생.
-> 해결하려면 이 행위를 추적해야하는데, 내 마이페이지는 네비바로 한번에 접근 가능하므로 필요 없을 것 같아 다른 사용자의 댓글 이미지에만 라우팅 구현.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

댓글에서 프로필 이미지를 클릭할 때 현재 사용자의 프로필을 제외하고 해당 사용자의 프로필 페이지로 이동하는 기능을 추가합니다. 프로필 이미지의 클릭 가능성을 반영하도록 댓글 상자 스타일을 개선합니다.

새로운 기능:
- 댓글에서 프로필 이미지를 클릭할 때, 사용자가 현재 사용자가 아닌 경우 해당 사용자의 프로필 페이지로 이동하는 기능을 구현합니다.

개선 사항:
- 프로필이 현재 사용자에게 속하는지 여부에 따라 클릭 가능성을 나타내기 위해 댓글 프로필 이미지에 조건부 스타일을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add functionality to navigate to a user's profile page when their profile image is clicked in a comment, excluding the current user's profile. Enhance the comment box styling to reflect the clickability of profile images.

New Features:
- Implement navigation to a user's profile page when clicking on their profile image in a comment, provided the user is not the current user.

Enhancements:
- Add conditional styling to the comment profile image to indicate clickability based on whether the profile belongs to the current user.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->