### PR TITLE
[Refactor] 라우터 어스프로텍트 의존성 추가

### DIFF
--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -5,7 +5,9 @@ import CategoryButtons from '@/components/page/search/CategoryButtons';
 import FilteredPlaylists from '@/components/page/search/FilteredPlaylists';
 import Input from '@/components/page/search/Input';
 import { useFilteredPlaylists } from '@/hooks/useFilteredPlaylists';
+import NotFoundPage from '@/pages/NotFound';
 import theme from '@/styles/theme';
+import { getUserIdBySession } from '@/utils/user';
 
 const Search = () => {
   const {
@@ -18,6 +20,11 @@ const Search = () => {
     isLoading,
   } = useFilteredPlaylists();
 
+  const sessionUid = getUserIdBySession();
+
+  if (!sessionUid) {
+    return <NotFoundPage />;
+  }
   return (
     <div css={containerStyle}>
       <header css={headerStyle}>

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -24,9 +24,8 @@ import Subscriptions from '@/pages/Subscriptions';
 
 const AuthProtectedRoute = () => {
   // 현재 경로와 URL쿼리 문자열 가져옴
-  const { pathname, search } = useLocation();
-  const navigate = useNavigate();
   const location = useLocation();
+  const navigate = useNavigate();
 
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -45,15 +44,12 @@ const AuthProtectedRoute = () => {
   }, [navigate]);
 
   useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
       const userSession = sessionStorage.getItem('userSession');
-      if (user) {
-        // 사용자가 인증되었지만 세션이 없는 경우
-        if (!userSession) {
-          await handleAuthLogout(); // 로그아웃 처리
-        } else {
-          setIsLoggedIn(true);
-        }
+      if (user && !userSession) {
+        handleAuthLogout();
+      } else {
+        setIsLoggedIn(!!user);
       }
       setIsLoading(false);
     });
@@ -70,11 +66,11 @@ const AuthProtectedRoute = () => {
 
   if (!isOnboarding) {
     // 온보딩을 완료하지 않았다면 온보딩 페이지로 이동
-    return <Navigate to={PATH.ONBOARDING} replace state={pathname + search} />;
+    return <Navigate to={PATH.ONBOARDING} replace state={location.pathname + location.search} />;
   }
   if (!isLoggedIn) {
     // 로그인하지 않았다면 로그인 페이지로 이동
-    return <Navigate to={PATH.SIGNIN} replace state={pathname + search} />;
+    return <Navigate to={PATH.SIGNIN} replace state={location.pathname + location.search} />;
   }
 
   return <Outlet />;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
close #221 
<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

검색페이지 세션값 없을시 404페이지로 이동하게 끔 수정
라우터 AuthProtectedRoute에 의존성 배열에 location을 추가하여 자식페이지간 이동할때마다 마운트 되게끔 수정
어스에서 가져온 로그인 정보와 세션값을 비교하여 로그인이 되어있는데 세션값이 없다면 로그아웃 로직 추가

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
