### PR TITLE
[Fix] 플레이리스트 메인 모달 오류

### DIFF
--- a/src/pages/PlaylistPage.tsx
+++ b/src/pages/PlaylistPage.tsx
@@ -200,7 +200,10 @@ const PlaylistPage: React.FC = () => {
       <Header
         Icon={playlist.userId === userId ? GoKebabHorizontal : undefined}
         customStyle={kebabStyle}
-        onIcon={() => setIsBottomSheetOpen(true)}
+        onIcon={() => {
+          setBottomSheetContentType('deleteFromPlaylist');
+          setIsBottomSheetOpen(true);
+        }}
         onBack={() =>
           prevUrl === PATH.DETAIL_LIST
             ? navigate(prevUrl, { state: { detailPagePlaylist } })


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
close #248 
<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

플레이리스트 메인페이지에서 동영상 삭제 모달후 플레이리스트 삭제 모달이 안뜨는 버그 수정

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

메인 페이지에서 재생 목록에서 비디오를 삭제한 후 재생 목록 삭제 모달이 나타나지 않는 버그를 수정합니다.

버그 수정:
- 메인 페이지에서 재생 목록에서 비디오를 삭제한 후 재생 목록 삭제 모달이 나타나지 않는 문제를 수정합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the bug preventing the playlist deletion modal from appearing after a video is deleted from the playlist on the main page.

Bug Fixes:
- Fix the issue where the playlist deletion modal does not appear after deleting a video from the playlist on the main page.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->