### PR TITLE
feat: 비디오 삭제 시 새로 인덱스 업데이트 기능 추가 (#242)

### DIFF
--- a/src/components/page/videoModal/VideoModal.tsx
+++ b/src/components/page/videoModal/VideoModal.tsx
@@ -34,6 +34,7 @@ const VideoModal = ({ isOpen, onClose, videoId, playlist, userId }: VideoModalPr
   const [currentPlaylist, setCurrentPlaylist] = useState(playlist);
   const [currentVideoId, setCurrentVideoId] = useState(videoId);
   const [currentVideoIndex, setCurrentVideoIndex] = useState(0);
+  const [isVideoEnded, setIsVideoEnded] = useState(false);
   const [iframeLoaded, setIframeLoaded] = useState(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const showToast = useToastStore((state) => state.showToast);
@@ -62,15 +63,44 @@ const VideoModal = ({ isOpen, onClose, videoId, playlist, userId }: VideoModalPr
       await handleDeleteVideo(updatedPlaylist.playlistId, selectedVideo.videoId);
       showToast('동영상이 성공적으로 삭제되었습니다.');
 
+      // 삭제된 비디오의 인덱스 찾기
+      const deletedIndex = updatedPlaylist.videos.findIndex(
+        (video) => video.videoId === selectedVideo.videoId
+      );
+
       // 삭제 후 플레이리스트 업데이트
-      if (currentVideoId === selectedVideo.videoId) {
-        const nextVideo = updatedPlaylist?.videos.find(
-          (video) => video.videoId !== selectedVideo.videoId
-        );
-        if (nextVideo) {
-          setCurrentVideoId(nextVideo.videoId || ''); // 다음 비디오로 전환: 다음 값이 있으면 다음 비디오로 전환
+      const updatedVideos = updatedPlaylist.videos.filter(
+        (video) => video.videoId !== selectedVideo.videoId
+      );
+      const newPlaylist = {
+        ...updatedPlaylist,
+        videos: updatedVideos,
+      };
+
+      setCurrentPlaylist(newPlaylist);
+
+      // 현재 재생 중인 비디오의 새 인덱스 찾기
+      const newCurrentVideoIndex = updatedVideos.findIndex(
+        (video) => video.videoId === currentVideoId
+      );
+
+      if (newCurrentVideoIndex !== -1) {
+        // 현재 재생 중인 비디오가 삭제되지 않았다면
+        setCurrentVideoIndex(newCurrentVideoIndex);
+      } else {
+        // 현재 재생 중인 비디오가 삭제되었다면
+        if (updatedVideos.length > 0) {
+          // 다음 비디오 재생 (또는 마지막 비디오였다면 첫 번째 비디오로)
+          const nextVideoIndex = Math.min(currentVideoIndex, updatedVideos.length - 1);
+          setCurrentVideoId(updatedVideos[nextVideoIndex].videoId || '');
+          setCurrentVideoIndex(nextVideoIndex);
         } else {
-          onClose(); // 마지막 비디오라면 모달을 닫음
+          // 모든 비디오가 삭제된 경우
+          setCurrentVideoId(''); // 비디오 ID 초기화
+          setCurrentVideoIndex(-1); // 비디오 인덱스 초기화
+          setIsVideoEnded(true); // 비디오 종료 상태로 변경
+          setIsPlaying(false); // 비디오 재생 중지
+          onClose(); // 모달 닫기
         }
       }
     } catch (error) {
@@ -126,6 +156,12 @@ const VideoModal = ({ isOpen, onClose, videoId, playlist, userId }: VideoModalPr
     const index = playlist.videos.findIndex((video) => video.videoId === currentVideoId);
     setCurrentVideoIndex(index !== -1 ? index : 0);
   }, [currentVideoId, playlist.videos]);
+
+  // currentVideoId나 currentPlaylist가 변경될 때마다 currentVideoIndex 업데이트
+  useEffect(() => {
+    const index = currentPlaylist.videos.findIndex((video) => video.videoId === currentVideoId);
+    setCurrentVideoIndex(index !== -1 ? index : 0);
+  }, [currentVideoId, currentPlaylist.videos]);
 
   const handleIframeLoad = () => {
     setIframeLoaded(true);
@@ -220,7 +256,9 @@ const VideoModal = ({ isOpen, onClose, videoId, playlist, userId }: VideoModalPr
               <div css={playlistInfoStyle}>
                 <h1>{playlist.title}</h1>
                 <span css={videoCountStyle}>
-                  {currentVideoIndex + 1} / {playlist.videos.length}
+                  {currentPlaylist.videos.length > 0
+                    ? `${currentVideoIndex + 1} / ${currentPlaylist.videos.length}`
+                    : '0 / 0'}
                 </span>
               </div>
               <div css={userNameStyle}>{playlist.userName}</div>
@@ -272,7 +310,7 @@ const VideoModal = ({ isOpen, onClose, videoId, playlist, userId }: VideoModalPr
                     ref={provided.innerRef}
                     css={[playlistContainerStyle, userId === playlist.userId ? '' : extraStyle]}
                   >
-                    {(updatedPlaylist?.videos || []).map(
+                    {(currentPlaylist.videos || []).map(
                       (
                         video,
                         index // 업데이트된 플레이리스트의 비디오 목록을 보여주거라


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 비디오 삭제 시 새로운 인덱스 업데이트 기능 추가
  - 재생 중인 비디오 삭제 시, 다음 비디오로 자동 재생되도록 기능 추가
    - 이때 삭제된 비디오의 인덱스를 기준으로 다음 비디오의 인덱스를 업데이트
    - 전체 비디오 목록에서 삭제된 비디오를 제외하고 총 갯수를 업데이트 함
    - 삭제되고 남은 비디오의 인덱스는 그대로 유지
    - 삭제된 비디오가 마지막 비디오인 경우,
      - 그 다음 비디오가 없으므로 재생 중인 비디오를 초기화
      - 영상이 멈춘 상태로 유지
  - 재생 중인 비디오가 아니라면, 재생중인 비디오를 초기화하지 않음
    - 삭제된 비디오의 인덱스를 기준으로 다음 비디오의 인덱스를 업데이트
    - 전체 비디오 목록에서 삭제된 비디오를 제외하고 총 갯수를 업데이트 함
  - 더이상 삭제할 비디오가 없는 경우, 모달을 닫음

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)


https://github.com/user-attachments/assets/dc96fc31-b431-4cc2-b869-e06012fd72b6



## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

비디오가 삭제될 때 비디오 인덱스와 재생 목록을 업데이트하는 기능을 구현하여 다음 비디오로의 원활한 전환을 보장하거나 재생 목록의 끝을 적절히 처리합니다.

새로운 기능:
- 현재 비디오가 삭제될 경우 다음 비디오가 자동으로 재생되도록 비디오가 삭제될 때 비디오 인덱스를 업데이트하는 기능 추가.

개선 사항:
- 비디오가 삭제될 때 변경 사항을 반영하여 비디오 재생 목록과 인덱스를 동적으로 업데이트하여 남은 비디오의 올바른 순서와 개수를 유지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a feature to update the video index and playlist when a video is deleted, ensuring seamless transition to the next video or handling the end of the playlist appropriately.

New Features:
- Add functionality to update video index when a video is deleted, ensuring the next video plays automatically if the current video is deleted.

Enhancements:
- Update the video playlist and index dynamically to reflect changes when videos are deleted, maintaining the correct order and count of remaining videos.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->