### PR TITLE
[Fix] 안쓰는 변수 삭제 및 eslint 수정

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -93,7 +93,7 @@ module.exports = {
     'react/jsx-no-duplicate-props': ['error', { ignoreCase: true }],
     // TypeScript 전용으로 설정
     '@typescript-eslint/no-unused-vars': [
-      'error', // 'warn'을 'error'로 변경
+      'warn',
       {
         varsIgnorePattern: '^_', // '_'로 시작하는 변수는 무시
         argsIgnorePattern: '^_', // '_'로 시작하는 함수 매개변수는 무시

--- a/src/components/page/videoModal/VideoModal.tsx
+++ b/src/components/page/videoModal/VideoModal.tsx
@@ -5,7 +5,6 @@ import { DragDropContext, Draggable, DragUpdate, Droppable, DropResult } from 'r
 import { GoX, GoChevronDown } from 'react-icons/go';
 import { MdDragHandle } from 'react-icons/md';
 import { RiPauseLine, RiPlayFill } from 'react-icons/ri';
-import { useNavigate } from 'react-router-dom';
 
 import BottomSheet from '@/components/common/modals/BottomSheet';
 import Spinner from '@/components/common/Spinner';
@@ -190,8 +189,8 @@ const VideoModal = ({ isOpen, onClose, videoId, playlist, userId }: VideoModalPr
   if (!updatedPlaylist) return null;
 
   return (
-    <div css={modalOverlayStyle(isMinimized, isClosing)}>
-      <div css={modalContentStyle(isMinimized, isClosing, isMaximizing, isOpen)}>
+    <div css={modalOverlayStyle(isMinimized)}>
+      <div css={modalContentStyle(isMinimized, isClosing)}>
         <div css={headerStyle(isMinimized)}>
           <Header LeftIcon={GoChevronDown} onBack={handleMinimize} />
         </div>
@@ -339,7 +338,7 @@ const playerContainerStyle = css`
   flex-direction: column;
 `;
 
-const modalOverlayStyle = (isMinimized: boolean, isClosing: boolean) => css`
+const modalOverlayStyle = (isMinimized: boolean) => css`
   position: ${isMinimized ? 'fixed' : 'sticky'};
   top: ${isMinimized ? 'auto' : '0'};
   left: 0;
@@ -357,17 +356,12 @@ const modalOverlayStyle = (isMinimized: boolean, isClosing: boolean) => css`
   margin: 0 auto;
 `;
 
-const modalContentStyle = (
-  isMinimized: boolean,
-  isClosing: boolean,
-  isMaximizing: boolean,
-  isOpen: boolean
-) => css`
+const modalContentStyle = (isMinimized: boolean, isClosing: boolean) => css`
   background-color: ${theme.colors.black};
   width: 498px;
   height: ${isMinimized ? '60px' : '100vh'};
   margin: 0 auto;
-  transform: translateY(${getTransformY(isMinimized, isClosing, isMaximizing)});
+  transform: translateY(${getTransformY(isMinimized, isClosing)});
   transition: all 300ms ease-out;
   display: flex;
   flex-direction: ${isMinimized ? 'row' : 'column'};
@@ -404,7 +398,7 @@ const modalContentStyle = (
   }
 `;
 
-const getTransformY = (isMinimized: boolean, isClosing: boolean, isMaximizing: boolean) => {
+const getTransformY = (isMinimized: boolean, isClosing: boolean) => {
   if (isClosing) return '100%';
   if (isMinimized) return 'calc(100% - 140px)';
   return '0';


### PR DESCRIPTION
95번째 줄 안쓰는 변수 관련 warn으로 재변경
비디오 모달에서 안쓰는 변수 최대한 삭제

# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

95번째 줄
```
    '@typescript-eslint/no-unused-vars': [
      'warn',으로 변경
```
## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

VideoModal 컴포넌트에서 사용되지 않는 변수를 제거하고 스타일 함수를 단순화하여 정리합니다. 사용되지 않는 변수에 대해 오류 대신 경고를 표시하도록 ESLint 구성을 조정합니다.

버그 수정:
- VideoModal 컴포넌트에서 사용되지 않는 변수를 제거하여 코드를 정리합니다.

개선 사항:
- 불필요한 매개변수를 제거하여 modalOverlayStyle 및 modalContentStyle 함수를 단순화합니다.

CI:
- 사용되지 않는 변수에 대한 엄격성을 줄이기 위해 '@typescript-eslint/no-unused-vars'에 대한 ESLint 규칙을 'error'에서 'warn'으로 변경합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clean up the VideoModal component by removing unused variables and simplifying style functions. Adjust the ESLint configuration to warn instead of error on unused variables.

Bug Fixes:
- Remove unused variables from the VideoModal component to clean up the code.

Enhancements:
- Simplify the modalOverlayStyle and modalContentStyle functions by removing unnecessary parameters.

CI:
- Change the ESLint rule for '@typescript-eslint/no-unused-vars' from 'error' to 'warn' to reduce strictness on unused variables.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->