### PR TITLE
fix: 자세히보기 버튼 아이콘 위치 수정 (#261)

### DIFF
--- a/src/components/common/buttons/IconTextButton.tsx
+++ b/src/components/common/buttons/IconTextButton.tsx
@@ -59,6 +59,9 @@ const getVariantStyle = (variant: IconButtonVariant) => {
         font-size: ${theme.fontSizes.small};
         font-weight: 500;
         color: ${theme.colors.white};
+        position: fixed;
+        left: 1rem;
+        bottom: 12px;
         padding: 16px 0;
         z-index: 100;
       `;

--- a/src/components/page/home/HorizontalList.tsx
+++ b/src/components/page/home/HorizontalList.tsx
@@ -101,6 +101,11 @@ const headerStyle = css`
   justify-content: space-between;
   align-items: center;
   margin: -0.5rem 1rem;
+  > button {
+    position: relative;
+    left: 0;
+    bottom: 0;
+  }
 `;
 
 const titleStyle = css`


### PR DESCRIPTION
홈 화면의 자세히보기 버튼 아이콘 위치를 수정
마이페이지의 자세히보기 버튼 아이콘 위치를 수정

# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
closes #261 
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

홈 화면의 자세히보기 버튼 아이콘 위치를 수정
마이페이지의 자세히보기 버튼 아이콘 위치를 수정

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

홈 화면과 마이 페이지 화면에서 '자세히보기' 버튼 아이콘의 위치를 수정하여 올바르게 표시되도록 합니다.

버그 수정:
- 홈 화면에서 '자세히보기' 버튼 아이콘의 위치를 수정합니다.
- 마이 페이지 화면에서 '자세히보기' 버튼 아이콘의 위치를 조정합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the positioning of the '자세히보기' button icons on both the home and My Page screens to ensure they are displayed correctly.

Bug Fixes:
- Correct the position of the '자세히보기' button icon on the home screen.
- Adjust the position of the '자세히보기' button icon on the My Page screen.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->