### PR TITLE
[Fix] 좋아요 1000개 이상일 때 뱃지가 보이지 않는 문제 수정 (#241)

### DIFF
--- a/src/components/page/mypage/MyProfile.tsx
+++ b/src/components/page/mypage/MyProfile.tsx
@@ -35,7 +35,7 @@ const MyProfile: React.FC<MyProfileProps> = ({ userData, playlists }) => {
   if (!userData) {
     return null;
   }
-  const hasBadge = userData.totalLikes >= 1000; // 좋아요 1000개 이상이면 뱃지 표시
+  const hasBadge = totalLikesCount ?? 0 >= 1000; //`좋아요` 1000개 이상일 때 뱃지 표시
 
   return (
     <div css={containerStyle}>
@@ -134,7 +134,7 @@ const a11yStyle = css`
   white-space: nowrap;
   border-width: 0;
 `;
-const bgStyle = (hasBadge: boolean) => css`
+const bgStyle = (hasBadge: number | boolean) => css`
   position: relative;
   top: 112px;
   left: 50%;


### PR DESCRIPTION
데이터 구조가 변경되었음 : userData에는 더이상 totalLikes가 없음
playlist의 totalLikesCount 사용
playlist가 가진 총 좋아요 수가 1000개 이상일 때 뱃지가 보이도록 수정

# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
closes #241 
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 데이터 구조가 변경되었음 : userData에는 더이상 totalLikes가 없음
- playlist의 totalLikesCount 사용
- playlist가 가진 총 좋아요 수가 1000개 이상일 때 뱃지가 보이도록 수정

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

<img width="450" alt="스크린샷 2024-09-17 오후 5 36 18" src="https://github.com/user-attachments/assets/12cc7f2b-9517-4a33-b143-0af07a3ff1e5">


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

플레이리스트의 'totalLikesCount'를 사용하여 총 좋아요 수가 1000을 초과할 때 배지를 표시하는 로직을 수정했습니다. 이전에는 userData의 'totalLikes'를 사용하고 있었습니다.

버그 수정:
- 올바른 데이터 구조를 사용하여 총 좋아요 수가 1000을 초과할 때 배지가 표시되지 않는 문제를 수정했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct the logic for displaying the badge when the total likes count exceeds 1000 by using the 'totalLikesCount' from the playlist instead of 'totalLikes' from userData.

Bug Fixes:
- Fix the issue where the badge was not displayed when the total likes exceeded 1000 by using the correct data structure.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->