### PR TITLE
[Fix] 플레이리스트 페이지에서 디테일 페이지로 navigate되지 않는 버그 해결

### DIFF
--- a/src/components/page/home/DetailList.tsx
+++ b/src/components/page/home/DetailList.tsx
@@ -11,26 +11,25 @@ import { formatTimeWithUpdated } from '@/utils/formatDate';
 
 interface LocationState {
   title: string;
-  playlists: PlaylistModel[];
+  detailPagePlaylists: PlaylistModel[];
 }
 
 const DetailList: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
-  const { title, playlists } = location.state as LocationState;
+  const { title, detailPagePlaylists } = location.state as LocationState;
 
   const handleThumbNailBoxClick = (playlist: PlaylistModel) => {
     navigate(`/playlist/${playlist.playlistId}`, {
-      state: { playlist, previousPath: location.pathname },
+      state: { detailPagePlaylists, previousPath: location.pathname },
     });
   };
-
   return (
     <div>
-      <Header onBack={() => navigate(-1)} />
+      <Header onBack={() => navigate('/')} />
       <div css={listStyle}>
         <h2 css={titleStyle}>{title}</h2>
-        {playlists.map((playlist) => (
+        {detailPagePlaylists.map((playlist) => (
           <ThumbNailBox
             key={playlist.playlistId}
             type='details'

--- a/src/components/page/home/HorizontalList.tsx
+++ b/src/components/page/home/HorizontalList.tsx
@@ -15,7 +15,7 @@ import { formatNumberToK } from '@/utils/formatNumber';
 
 interface CrossScrollingListProps {
   title: string;
-  playlists: PlaylistModel[];
+  detailPagePlaylists: PlaylistModel[];
 }
 
 const SEE = {
@@ -23,15 +23,15 @@ const SEE = {
   ALL: '전체보기',
 };
 
-const HorizontalList: React.FC<CrossScrollingListProps> = ({ title, playlists }) => {
+const HorizontalList: React.FC<CrossScrollingListProps> = ({ title, detailPagePlaylists }) => {
   const scrollRef = useRef<HTMLDivElement>(null);
   const { handlers, showLeftArrow, showRightArrow, scrollLeftFunc, scrollRightFunc } =
     useScrollWithArrows(scrollRef);
   const navigate = useNavigate();
-  const hasRightPadding = playlists.length <= 8;
+  const hasRightPadding = detailPagePlaylists.length <= 8;
 
   const handleMoreClick = () => {
-    navigate(PATH.DETAIL_LIST, { state: { title, playlists } });
+    navigate(PATH.DETAIL_LIST, { state: { title, detailPagePlaylists } });
   };
 
   return (
@@ -54,7 +54,7 @@ const HorizontalList: React.FC<CrossScrollingListProps> = ({ title, playlists })
           </div>
         )}
         <div css={scrollContainerStyle(hasRightPadding)} ref={scrollRef} {...handlers}>
-          {playlists.map((playlist) => (
+          {detailPagePlaylists.map((playlist) => (
             <div
               key={playlist.playlistId}
               css={playlistItemStyle}
@@ -74,7 +74,7 @@ const HorizontalList: React.FC<CrossScrollingListProps> = ({ title, playlists })
               />
             </div>
           ))}
-          {playlists.length > 8 && (
+          {detailPagePlaylists.length > 8 && (
             <div css={moreButtonStyle} onClick={handleMoreClick}>
               <IconButton Icon={RiAddLargeLine} />
               <p>{SEE.MORE}</p>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -19,12 +19,12 @@ const Home = () => {
       {interestedPlaylists.allForkedPlaylists.length > 0 && (
         <HorizontalList
           title={INTERESTED_PLAYLIST}
-          playlists={interestedPlaylists.allForkedPlaylists}
+          detailPagePlaylists={interestedPlaylists.allForkedPlaylists}
         />
       )}
       <HorizontalList
         title={POPULAR_PLAYLIST}
-        playlists={popularAndRecentPlaylists.playlistsByPopularity}
+        detailPagePlaylists={popularAndRecentPlaylists.playlistsByPopularity}
       />
       <RecentUpdateList
         title={RECENTUPDATE_PLAYLIST}

--- a/src/pages/PlaylistPage.tsx
+++ b/src/pages/PlaylistPage.tsx
@@ -39,7 +39,7 @@ const PlaylistPage: React.FC = () => {
   const userId = getUserIdBySession();
   const [youtubeUrl, setYoutubeUrl] = useState('');
   const { prevUrl, setPrevUrl } = usePrevUrlStore();
-  const { detailPagePlaylist, setDetailPagePlaylist } = usePrevUrlStore();
+  const { detailPagePlaylists, setDetailPagePlaylist } = usePrevUrlStore();
 
   const {
     playlist,
@@ -70,8 +70,8 @@ const PlaylistPage: React.FC = () => {
     if (location.state && !location.state.previousPath.includes('comment'))
       setPrevUrl(location.state.previousPath);
 
-    if (!location.state.playlist) return;
-    setDetailPagePlaylist(location.state.playlist);
+    if (!location.state.detailPagePlaylists) return;
+    setDetailPagePlaylist(location.state.detailPagePlaylists);
   }, []);
 
   useEffect(() => {
@@ -201,7 +201,7 @@ const PlaylistPage: React.FC = () => {
         }}
         onBack={() =>
           prevUrl === PATH.DETAIL_LIST
-            ? navigate(prevUrl, { state: { detailPagePlaylist } })
+            ? navigate(prevUrl, { state: { detailPagePlaylists } })
             : navigate(prevUrl)
         }
       />

--- a/src/store/usePrevUrlStore.ts
+++ b/src/store/usePrevUrlStore.ts
@@ -5,13 +5,13 @@ import { PlaylistModel } from '@/types/playlist';
 interface PrevUrlProps {
   prevUrl: string;
   setPrevUrl: (prevUrl: string) => void;
-  detailPagePlaylist: PlaylistModel[];
+  detailPagePlaylists: PlaylistModel[];
   setDetailPagePlaylist: (playlist: PlaylistModel[]) => void;
 }
 
 export const usePrevUrlStore = create<PrevUrlProps>((set) => ({
   prevUrl: '',
   setPrevUrl: (prevUrl: string) => set({ prevUrl }),
-  detailPagePlaylist: [],
-  setDetailPagePlaylist: (playlist: PlaylistModel[]) => set({ detailPagePlaylist: playlist }),
+  detailPagePlaylists: [],
+  setDetailPagePlaylist: (playlist: PlaylistModel[]) => set({ detailPagePlaylists: playlist }),
 }));


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 플레이리스트 페이지로 넘어갈 때 디테일 페이지에 표시되는 playlists 항목을 넘겨주지 않았음

<!-- Generated by sourcery-ai[bot]: start summary -->

## Sourcery에 의한 요약

플레이리스트 페이지에서 상세 페이지로의 탐색을 방해하는 버그를 해결하기 위해 컴포넌트 간에 플레이리스트 정보를 전달하는 데 사용되는 데이터 구조를 업데이트합니다.

버그 수정:
- 올바른 플레이리스트 데이터가 전달되도록 하여 플레이리스트 페이지에서 상세 페이지로의 탐색 문제를 해결합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve a bug preventing navigation from the playlist page to the detail page by updating the data structure used to pass playlist information between components.

Bug Fixes:
- Fix navigation issue from the playlist page to the detail page by ensuring the correct playlist data is passed.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->